### PR TITLE
Added check to F1 and F2 quad flags get swapped in magnitude mode only.

### DIFF
--- a/nmrglue/process/pipe_proc.py
+++ b/nmrglue/process/pipe_proc.py
@@ -1536,8 +1536,9 @@ def tp(dic, data, hyper=False, nohyper=False, auto=False, nohdr=False):
     dic['FDDIMORDER'] = [dic["FDDIMORDER1"], dic["FDDIMORDER2"],
                          dic["FDDIMORDER3"], dic["FDDIMORDER4"]]
     
-    dic['FDF1QUADFLAG'], dic['FDF2QUADFLAG'] = (dic['FDF2QUADFLAG'], 
-                                                dic['FDF1QUADFLAG'])
+    if dic["FD2DPHASE"] == 0:
+        dic['FDF1QUADFLAG'], dic['FDF2QUADFLAG'] = (dic['FDF2QUADFLAG'], 
+                                                    dic['FDF1QUADFLAG'])
 
     if nohdr is not True:
         dic["FDTRANSPOSED"] = (dic["FDTRANSPOSED"] + 1) % 2


### PR DESCRIPTION
The F1/F2 quad flag swap breaks complex processing.  I added a test so the swap only happens if the 2D plane is magnitude mode.  Checked this works on 2D HMBC (magnitude) and 2D HSQC (states).
