### PR TITLE
ENH: nmrglue.bruker.scale_pdata function

### DIFF
--- a/doc/source/reference/bruker.rst
+++ b/doc/source/reference/bruker.rst
@@ -25,6 +25,7 @@ These are functions which are targetted for users of nmrglue.
     read_binary
     write_binary
     read_pdata_binary
+    scale_pdata
     read_binary_lowmem
     write_binary_lowmem
     read_jcamp


### PR DESCRIPTION
The nmrglue.bruker.scale_pdata function scales processed Bruker data in the
same manner as is done in Topspin and other programs.  The scale_data
parameter added to nmrglue.bruker.read_pdata will perform this scaling during
reading of the processed data.