### PR TITLE
Automatic phase correction

### DIFF
--- a/nmrglue/process/__init__.py
+++ b/nmrglue/process/__init__.py
@@ -2,3 +2,4 @@ from . import proc_base
 from . import proc_bl
 from . import pipe_proc
 from . import proc_lp
+from . import proc_autophase

--- a/nmrglue/process/proc_autophase.py
+++ b/nmrglue/process/proc_autophase.py
@@ -1,0 +1,129 @@
+"""
+Automated phase correction
+These functions provide support for automatic phasing of NMR data. They 
+consist of the core `autops` function which performs the optimisation and
+a set of private functions for calculating a spectral phase quality score
+for a provided spectrum.
+"""
+
+import numpy as np
+import scipy.optimize
+
+from .proc_base import ps
+
+def autops(data, fn, p0=0.0, p1=0.0):
+    """
+    Automatic linear phase correction
+
+    Parameters
+    ----------
+    data : ndarray
+        Array of NMR data.
+    fn : str or function
+        Algorithm to use for phase scoring. Built in functions can be
+        specified by one of the following strings: "acme", "peak_minima"
+    p0 : float
+        Initial zero order phase in degrees.
+    p1 : float
+        Initial first order phase in degrees.
+
+    Returns
+    -------
+    ndata : ndarray
+        Phased NMR data.
+
+    """
+    if not callable(fn):
+        fn = {
+            'peak_minima': _ps_peak_minima_score,
+            'acme': _ps_acme_score,
+        }[fn]
+    
+    opt = [p0, p1]
+    opt = scipy.optimize.fmin(fn, x0=opt, args=(data, ))
+    
+    phasedspc = ps(data, p0=opt[0], p1=opt[1])    
+
+    return phasedspc
+
+def _ps_acme_score(ph, data):
+    """
+    Phase correction using ACME algorithm by Chen Li et al. 
+    Journal of Magnetic Resonance 158 (2002) 164-168
+
+    Parameters
+    ----------
+    pd : tuple
+        Current p0 and p1 values
+    data : ndarray
+        Array of NMR data.
+
+    Returns
+    -------
+    score : float
+        Value of the objective function (phase score)
+
+    """        
+    stepsize = 1
+
+    phc0, phc1 = ph
+
+    s0 = ps(data, p0=phc0, p1=phc1)
+    data = np.real(s0)
+
+    # Calculation of first derivatives
+    ds1 = np.abs((data[1:]-data[:-1]) / (stepsize*2))
+    p1 = ds1 / np.sum(ds1)
+
+    # Calculation of entropy
+    p1[p1 == 0] = 1
+
+    h1 = -p1 * np.log(p1)
+    h1s = np.sum(h1)
+
+    # Calculation of penalty
+    pfun = 0.0
+    as_ = data - np.abs(data)
+    sumas = np.sum(as_)
+
+    if sumas < 0:
+        pfun = pfun + np.sum((as_/2) ** 2)
+
+    p = 1000 * pfun
+    
+    return h1s + p
+
+
+def _ps_peak_minima_score(ph, data):
+    """
+    Phase correction using simple minima-minimisation around highest peak
+
+    This is a naive approach but is quick and often achieves reasonable 
+    results.  The optimisation is performed by finding the highest peak in the 
+    spectra (e.g. TMSP) and then attempting to reduce minima surrounding it.
+    
+    Parameters
+    ----------
+    pd : tuple
+        Current p0 and p1 values
+    data : ndarray
+        Array of NMR data.
+
+    Returns
+    -------
+    score : float
+        Value of the objective function (phase score)
+
+    """ 
+
+    phc0, phc1 = ph
+
+    s0 = ps(data, p0=phc0, p1=phc1)
+    data = np.real(s0)
+
+    i = np.argmax(data)
+    mina = np.min(data[i-100:i])
+    minb = np.min(data[i:i+100])
+
+    return np.abs(mina - minb)
+


### PR DESCRIPTION
An initial implementation of automatic phase correction for consideration.
This adds a new function to `proc_base` of `autops`, alongside two example
phase optimisation (scoring) algorithms: ACME and a naive peak minima approach.

Standard algorithms can be selected by name ('acme', 'peak_minima') while
custom algorithms can be provided as a function.

A [demo notebook is available](https://github.com/mfitzp/ipython-notebooks/blob/master/public/Automatic%20phase%20correction%20of%20NMR%20spectra.ipynb).