### PR TITLE
Update proc_autophase.py

### DIFF
--- a/nmrglue/process/proc_autophase.py
+++ b/nmrglue/process/proc_autophase.py
@@ -38,6 +38,7 @@ def psacme(autops(data, p0=0.0, p1=0.0, gamma=5.0e-3, optreturn=False):
         phases returned by algoritm in a tuple
 
     """
+
     opt = [p0, p1]
     opt = scipy.optimize.fmin(_ps_acme_score, x0=opt, args=(data, gamma))
 
@@ -72,6 +73,7 @@ def pspmin(autops(data, p0=0.0, p1=0.0, optreturn=False):
         phases returned by algoritm in a tuple
 
     """
+
     opt = [p0, p1]
     opt = scipy.optimize.fmin(_ps_acme_score, x0=opt, args=(data,))
 

--- a/nmrglue/process/proc_autophase.py
+++ b/nmrglue/process/proc_autophase.py
@@ -89,7 +89,7 @@ def _ps_acme_score(ph, data):
     data = np.real(s0)
 
     # Calculation of first derivatives
-    ds1 = np.diff(data, nderiv)
+    ds1 = np.abs(np.diff(data, nderiv))
     p1 = ds1 / np.sum(ds1)
 
     # Calculation of entropy


### PR DESCRIPTION
The Automatic phase correction did not work as intended. Especially the penalty function was calculated incorrectly. I think.
Also there should be an option to set the derivative order and a penalty function scaling factor, gamma.

I would suggest that the function also returned the optimum phases.
In the case where 100's of spectra should be processed it would be nice to be able to store the phases in case one wants to reprocess.