### PR TITLE
ENH: reference processed Bruker strip transformed data

### DIFF
--- a/examples/bruker_processed_2d/bruker_processed_2d.py
+++ b/examples/bruker_processed_2d/bruker_processed_2d.py
@@ -1,0 +1,31 @@
+#! /usr/bin/env python
+"""
+Read and Plot pre-processed data.
+"""
+import os
+import nmrglue as ng
+import matplotlib.pyplot as plt
+
+# Find the data
+file_path = os.path.dirname(__file__)
+data_file = os.path.join(file_path, 'data', 'bruker_exp', '1', 'pdata', '1')
+
+# Read the data
+dic, data = ng.bruker.read_pdata(data_file)
+
+udic = ng.bruker.guess_udic(dic, data, strip_fake=True)
+
+# make ppm scales
+uc_13c = ng.fileiobase.uc_from_udic(udic, dim=1)
+ppm_13c = uc_13c.ppm_scale()
+ppm_13c_0, ppm_13c_1 = uc_13c.ppm_limits()
+
+uc_15n = ng.fileiobase.uc_from_udic(udic, dim=0)
+ppm_15n = uc_15n.ppm_scale()
+ppm_15n_0, ppm_15n_1 = uc_15n.ppm_limits()
+
+plt.figure()
+plt.contour(data, extent=(ppm_13c_0, ppm_13c_1, ppm_15n_0, ppm_15n_1))
+plt.gca().invert_yaxis()
+plt.gca().invert_xaxis()
+plt.show()


### PR DESCRIPTION
For consideration: a fix for issue #49; when Bruker parameters STSI and/or STSR are set, the spectrum read by `bruker.read_pdata` is incorrectly referenced. 

An optional bool parameter was added to `bruker.guess_udic` called `strip_fake`. If set to `True` and if the dic has the parameters STSI or STSR  the sweep width and carrier frequency is faked so that `unit_conversion` objects can be used like normal.