### PR TITLE
Correct frequency scale values from unit_conversion class

### DIFF
--- a/nmrglue/fileio/fileiobase.py
+++ b/nmrglue/fileio/fileiobase.py
@@ -78,10 +78,10 @@ class unit_conversion():
         self._sw = sw
         self._obs = obs
         self._car = car
-
+        
         # derived units (these are in ppm)
         self._delta = -self._sw / (self._size * self._obs)
-        self._first = self._car / self._obs - self._delta * (self._size - 1) / 2.
+        self._first = self._car / self._obs - self._delta * (self._size//2).
 
     # individual unit conversion functions
     def __percent2pts(self, percent):
@@ -385,16 +385,19 @@ def uc_from_freqscale(scale, obs, unit='ppm'):
         # bin width (to convert from centers to edges).
         dx = abs(scale[1]-scale[0])
 
+        # car is assumed to be in the middle of the scale array
+        # and on the lower frequency side of the array for even size
+        # (corresponding to the behaviour of np.fft.fftshift)
         if unit is 'ppm':
             sw = ((max + dx/2.0) - (min - dx/2.0)) * obs
-            car = (min-dx/2.0 + (max-min+dx)/2.0) * obs
+            car = (min + dx*(size//2)) * obs
         elif unit is 'hz':
             sw = ((max + dx/2.0) - (min - dx/2.0))
-            car = (min-dx/2.0 + (max-min+dx)/2.0)
+            car = (min + dx*(size//2))
         else:
             # unit is 'kHz':
             sw = ((max + dx/2.0) - (min - dx/2.0)) / 1.e3
-            car = (min-dx/2.0 + (max-min+dx)/2.0) / 1.e3
+            car = (min + dx*(size//2)) / 1.e3
 
     else:
         mesg = '{} is not a supported unit.'.format(unit)

--- a/nmrglue/fileio/fileiobase.py
+++ b/nmrglue/fileio/fileiobase.py
@@ -387,14 +387,14 @@ def uc_from_freqscale(scale, obs, unit='ppm'):
 
         if unit is 'ppm':
             sw = ((max + dx/2.0) - (min - dx/2.0)) * obs
-            car = (min-dx/2.0 + (max-min)/2.0) * obs
+            car = (min-dx/2.0 + (max-min+dx)/2.0) * obs
         elif unit is 'hz':
             sw = ((max + dx/2.0) - (min - dx/2.0))
-            car = (min-dx/2.0 + (max-min)/2.0)
+            car = (min-dx/2.0 + (max-min+dx)/2.0)
         else:
             # unit is 'kHz':
             sw = ((max + dx/2.0) - (min - dx/2.0)) / 1.e3
-            car = (min-dx/2.0 + (max-min)/2.0) / 1.e3
+            car = (min-dx/2.0 + (max-min+dx)/2.0) / 1.e3
 
     else:
         mesg = '{} is not a supported unit.'.format(unit)

--- a/nmrglue/fileio/fileiobase.py
+++ b/nmrglue/fileio/fileiobase.py
@@ -81,7 +81,7 @@ class unit_conversion():
 
         # derived units (these are in ppm)
         self._delta = -self._sw / (self._size * self._obs)
-        self._first = self._car / self._obs - self._delta * self._size / 2.
+        self._first = self._car / self._obs - self._delta * (self._size - 1) / 2.
 
     # individual unit conversion functions
     def __percent2pts(self, percent):


### PR DESCRIPTION
In the previous way, all spectral scales had their first point at the very edge of the spectral window instead of half point distance away. This led the whole spectra be shifted a half point distance. For example, the first point, the middle between first and last point as well as the last point were at `car/obs - delta*size/2`, `car/obs - delta/2` and `car/obs + delta*(size/2 - 1)`. Now these positions are symmetric at `car/obs - delta*(size - 1)/2`, `car/obs` and `car/obs + delta*(size - 1)/2`. Moreover, now the middle of the spectrum is independent from the size of the data array. I think this is the usual way to distribute the data points over the spectral window ~~and is also consistent with the method to create a unit conversion object from a frequency scale (see line 384)~~. I hope I made no mistakes in my considerations.