### PR TITLE
BUG: Bruker sub-matices only reordered once

### DIFF
--- a/nmrglue/fileio/bruker.py
+++ b/nmrglue/fileio/bruker.py
@@ -1077,7 +1077,7 @@ def read_pdata_binary(filename, shape=None, submatrix_shape=None, big=True):
     else:
         try:
             data = reorder_submatrix(data, shape, submatrix_shape)
-            return dic, reorder_submatrix(data, shape, submatrix_shape)
+            return dic, data
         except:
             warn('unable to reorder data')
             return dic, data


### PR DESCRIPTION
When reading Bruker sub-matrices with the read_pdata_binary or read_pdata
function in the bruker module the sub-matrices are only re-ordered once.
Previously two re-ordering were performed which resulted in incorrect data
being returned by these functions.

closes #58