### PR TITLE
Bruker guess_udic  now works when read_acqus=False

### DIFF
--- a/nmrglue/fileio/bruker.py
+++ b/nmrglue/fileio/bruker.py
@@ -122,7 +122,7 @@ def add_axis_to_udic(udic, dic, udim, strip_fake):
     if acq_file in dic:
         sw = dic[acq_file]["SW_h"]
     elif pro_file in dic:
-        sw = dic[pro_file]["SW_p"]   
+        sw = dic[pro_file]["SW_p"]  
         # procNs files store sw (in Hz) with the 'SW_p' key instead of 'SW_h'.
         # this is a bug in TopSpin (TopSpin3.5pl7)
 
@@ -136,9 +136,9 @@ def add_axis_to_udic(udic, dic, udim, strip_fake):
         if acq_file in dic:
             car = (dic[acq_file]["SFO1"] - obs) * 1e6
         else:
-            # we should be able to use the 'OFFSET' parameter in procNs to 
+            # we should be able to use the 'OFFSET' parameter in procNs to
             # calculate 'car'. But this is slightly off (~ 5E-3 Hz)
-            # most likely because the procs file does not store the OFFSET 
+            # most likely because the procs file does not store the OFFSET
             # to a high precision. Hence the value in acquNs is given priority
             car = dic[pro_file]["OFFSET"]*obs - sw/2
  


### PR DESCRIPTION
Currently, `bruker.guess_udic` and `bruker.add_axis_to_udic` fail when acqus files are unavailable or if they are called with `read_acqus=False`. Most of the parameters which it tries to look up in acqus are also available in procs. I have added conditionals to `bruker.add_axis_to_udic` where spectral width, carrier offset, axis name and acquisition mode will be looked up in procs as well as acqus. Most of the places, preference is given to the acqus files, but there are some use cases (such as post-acquisition re-scaling of spectral widths) where one should be reading specifically from the procs files.
This PR does not change the default behaviour of the functions.
