### PR TITLE
Reading simpson files: fixes cases where multiple FIDs are concatenated

### DIFF
--- a/nmrglue/fileio/simpson.py
+++ b/nmrglue/fileio/simpson.py
@@ -156,15 +156,19 @@ def read_text(filename):
     for key in ['SW1', 'SW']:    # convert keys to floats
         if key in dic:
             dic[key] = float(dic[key])
-    for key in ['NP', 'NI']:    # convert keys to ints
+    for key in ['NP', 'NI', 'NELEM']:    # convert keys to ints
         if key in dic:
             dic[key] = int(dic[key])
+
+    # set NELEM to 1 if its a single 1D/2D dataset
+    if 'NELEM' not in dic:
+        dic['NELEM'] = 1
 
     # DEBUGGING
     # return dic
 
     if "NI" in dic:     # 2D data
-        data = np.empty((dic['NI'], dic['NP']), dtype='complex64')
+        data = np.empty((dic['NI']*dic['NELEM'], dic['NP']), dtype='complex64')
 
         # loop over remaining lines, extracting data values
         for iline, line in enumerate(f):
@@ -176,7 +180,7 @@ def read_text(filename):
             data.imag[ni_idx, np_idx] = i_val
 
     else:   # 1D data
-        data = np.empty((dic['NP']), dtype='complex64')
+        data = np.empty((dic['NP']*dic['NELEM']), dtype='complex64')
 
         # loop over remaining lines, extracting data values
         for iline, line in enumerate(f):
@@ -185,6 +189,7 @@ def read_text(filename):
             r_val, i_val = [float(i) for i in line.split()]
             data.real[iline] = r_val
             data.imag[iline] = i_val
+        data = data.reshape(dic['NELEM'], -1)
 
     f.close()
     return dic, data

--- a/nmrglue/fileio/simpson.py
+++ b/nmrglue/fileio/simpson.py
@@ -328,9 +328,12 @@ def read_binary(filename):
     for key in ['SW1', 'SW']:    # convert keys to floats
         if key in dic:
             dic[key] = float(dic[key])
-    for key in ['NP', 'NI']:    # convert keys to ints
+    for key in ['NP', 'NI', 'NELEM']:    # convert keys to ints
         if key in dic:
             dic[key] = int(dic[key])
+
+    if not 'NELEM' in dic.keys():
+        dic['NELEM'] = 1
 
     # DEBUGGING
     # return dic, f
@@ -359,10 +362,10 @@ def read_binary(filename):
 
     # reorder data according to dimensionality and domain
     if 'NI' in dic:  # 2D data
-        return dic, data.reshape(dic["NI"], dic["NP"])
+        return dic, data.reshape(dic['NI']*dic['NELEM'], dic['NP'])
 
     else:   # 1D data
-        return dic, data
+        return dic, data.reshape(dic['NELEM'], dic['NP'])
 
 BASE = 33
 FIRST = lambda f, x: ((x) & ~(~0 << f))


### PR DESCRIPTION
Simpson can generate multiple datasets when multiple detect operators are specified. These are written as concatenated datasets and the number of such datasets is indicated by the keyword 'NELEM' in the simpson text and binary data formats. This PR fixes the functions read_text and read_binary to read in such a dataset. In cases where there is only a single FID, the keyword 'NELEM' is set to 1 and the data will be read in as usual, but an extra key 'NELEM' will be added to the dictionary. With this functionality, it is not possible to write data in xreim, xyreim and raw_binary formats, so those functions are not modified.
An example file in the text format is attached.

[out.fid.zip](https://github.com/jjhelmus/nmrglue/files/2223267/out.fid.zip)
