### PR TITLE
BUG FIX: Bruker guess_shape calculation for 3rd and 4th dimensions

### DIFF
--- a/nmrglue/fileio/bruker.py
+++ b/nmrglue/fileio/bruker.py
@@ -840,7 +840,7 @@ def guess_shape(dic):
     # additional dimension given by data size
     if shape[2] != 0 and shape[3] != 0:
         shape[1] = fsize // (shape[3] * shape[2] * 4)
-        shape[0] = fsize // (shape[3] * shape[2] * 16 * 4)
+        shape[0] = fsize // (shape[3] * shape[2] * shape[1] * 4)
 
     # if there in no pulse program parameters in dictionary return currect
     # shape after removing zeros


### PR DESCRIPTION
3D and 4D files are often read with wrong 3rd and 4th dimensions as the number of points in the 3rd dimension were hard-coded to 16. This PR fixes that.