### PR TITLE
Read and write files so that Topspin can read them

### DIFF
--- a/nmrglue/fileio/bruker.py
+++ b/nmrglue/fileio/bruker.py
@@ -840,7 +840,7 @@ def guess_shape(dic):
     # additional dimension given by data size
     if shape[2] != 0 and shape[3] != 0:
         shape[1] = fsize // (shape[3] * shape[2] * 4)
-        shape[0] = fsize // (shape[3] * shape[2] * 16 * 4)
+        shape[0] = fsize // (shape[3] * shape[2] * shape[1] * 4)
 
     # if there in no pulse program parameters in dictionary return currect
     # shape after removing zeros


### PR DESCRIPTION
Currently, the functionality to write files in Bruker's formats is pretty good, but the files are not written out in a way that will make them accessible from Topspin. 2 things need to be done to make this happen: (i) Write acquN files in addition to acquNs files and (ii) write out the procN and procNs files in the correct subfolders. These commits give options to the user to do these things via `write` and `read` functions in `bruker.py`. The following changes are made:

1. `bruker.write` will now write acquN files in addition to acquNs files to the given directory. These will be identical files. Another option was to read and write out the `acquN`, but that adds unnecessary keys to the dictionary. This is a change in default behaviour, but it seems harmless to me even if the purpose of writing out the file was is not to read back the data in Topspin (one additional file is written out). 
2. If `read_procs` is set to True in the `bruker.read` function, any pdata folders inside the given directory will also be searched and by default the procNs files in folder number 1 will be read. If folder number 1 in not present, one of the other folders is read in. 
3. `write` has 3 new arguments (`procs_files`, `write_procs`, and `pdata_folder`). The first two arguments are similar to their `acqus` counterparts. `pdata_folder` will allow the user to define a (integer) subfolder where these are stored. By default, all the options are disabled, so the behaviour of the function should not be altered otherwise.

At some point in the (hopefully) near future, I plan to put in functionality to write out processed data that can be read in Topspin. The additions in this PR will be required to be able to read these data back in Topspin. In any case, these additions already help out in pre-processing the data (for example, splitting and sorting interleaved datasets) that can be then processed in Topspin.
