### PR TITLE
Modification of pipe.py for handling data that was applied  'nmrPipe -fn EXT' in z-dim

### DIFF
--- a/nmrglue/fileio/pipe.py
+++ b/nmrglue/fileio/pipe.py
@@ -1792,10 +1792,23 @@ class pipe_3d(fileiobase.data_nd):
         # find the length of the third dimension
         f3 = "FDF" + str(int(dic["FDDIMORDER3"]))
         quadrature_factor = [2, 1][int(dic[f3 + 'QUADFLAG'])]
+        
+        #Checking whether "nmrPipe -fn EXT ..." has been applied to z-dim or not.
+        #If EXT has been applied, FDF*XN is not zero.
+        #If z-dim is in time-domain, data-size given by FDF*X1 and FDF*XN has to be doubled.
         if dic[f3 + 'FTFLAG']:
-            lenZ = int(dic[f3 + 'FTSIZE'] * quadrature_factor)
+
+            if int(dic[f3 + 'XN']) == 0:
+                lenZ = int(dic[f3 + 'FTSIZE'] * quadrature_factor)
+            else:
+                lenZ = int(dic[f3 + 'XN']) - int(dic[f3 + 'X1']) + 1
+
         else:
-            lenZ = int(dic[f3 + 'TDSIZE'] * quadrature_factor)
+            if int(dic[f3 + 'XN']) == 0:
+                lenZ = int(dic[f3 + 'TDSIZE'] * quadrature_factor)
+            else:
+                lenZ = 2*(int(dic[f3 + 'XN']) - int(dic[f3 + 'X1']) + 1)
+                
         fshape.insert(0, lenZ)   # insert as leading size of fshape
 
         # check that all files exist if fcheck is set


### PR DESCRIPTION
3D nmrpipe file that was applied 'nmrPipe -fn EXT...' in z-dim could not be loaded by nmrglue.pipe.read().

I think, the trouble was originated length of z-dim was given by FDF\*FTSIZE or FDF\*TDSIZE. nmrPipe doesn't touch those parameters even EXT was applied. I would suggest using FDF\*X1 and FDF\*XN parameters for EXT applied data.