### PR TITLE
Correctly guessing spectral widths in multidimensional datasets

### DIFF
--- a/nmrglue/fileio/bruker.py
+++ b/nmrglue/fileio/bruker.py
@@ -121,7 +121,10 @@ def add_axis_to_udic(udic, dic, udim, strip_fake):
         pro_file = "procs"
 
     if acq_file in dic:
-        sw = dic[acq_file]["SW_h"]
+        if b_dim == 0:
+            sw = dic[acq_file]["SW_h"]
+        else:
+            sw = dic[acq_file]["SW"] * dic[acq_file]["SFO1"]
     elif pro_file in dic:
         sw = dic[pro_file]["SW_p"]
         # procNs files store sw (in Hz) with the 'SW_p' key instead of 'SW_h'.


### PR DESCRIPTION
The `bruker.guess_udic` and the underlying `add_axes_to_udic` only looked up parameters present in the `acqus` file and failed for higher dimensions. The `SW_h` key is not available for indirect dimensions and the spectral width is now calculated from `SW` and `SFO1` parameters. This PR does not change default behavior.