### PR TITLE
Fix FutureWarning in peak picking

### DIFF
--- a/nmrglue/analysis/peakpick.py
+++ b/nmrglue/analysis/peakpick.py
@@ -395,7 +395,7 @@ def extract_1d(data, location, axis):
     """
     s = [slice(v, v + 1) for v in location]
     s[axis] = slice(None, None)
-    return np.atleast_1d(np.squeeze(data[s]))
+    return np.atleast_1d(np.squeeze(data[tuple(s)]))
 
 
 # algorithm specific peak picking routines


### PR DESCRIPTION
Fix the following FutureWarning caused by a recent numpy version (at
least 1.16.4, maybe even before that):

nmrglue/analysis/peakpick.py:398: FutureWarning: Using a non-tuple
sequence for multidimensional indexing is deprecated; use
`arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be
interpreted as an array index, `arr[np.array(seq)]`, which will result
either in an error or a different result.
      return np.atleast_1d(np.squeeze(data[s])