### PR TITLE
Allow text values in JCAMP files without brackets

### DIFF
--- a/nmrglue/fileio/bruker.py
+++ b/nmrglue/fileio/bruker.py
@@ -2197,13 +2197,21 @@ def parse_jcamp_value(text):
     """
     Parse value text from Bruker JCAMP-DX file returning the value.
     """
-    if "<" in text:
+    if text == '':
+        return None
+    elif text.startswith('<') and text.endswith('>'):
         return text[1:-1]  # remove < and >
-    elif "." in text or "e" in text or 'inf' in text:
-        return float(text)
     else:
-        return int(text)
-
+        if "." in text or "e" in text or 'inf' in text:
+            try:
+                return float(text)
+            except ValueError:
+                return text
+        else:
+            try:
+                return int(text)
+            except ValueError:
+                return text
 
 def write_jcamp(dic, filename, overwrite=False):
     """


### PR DESCRIPTION
Allow text values in JCAMP files which aren't surrounded by angle
brackets. Remove angle brackets only if they indeed surround the value.
Try parsing the value to numerical types, and return a string if parsing
fails.

Although I didn't read the JCAMP specification, a quick look at [JCAMP for NMR (1993), Example 4](http://jcamp-dx.org/protocols/dxnmr01.pdf) makes me believe that the angle brackets are not required for text values.