### PR TITLE
Allow different encodings for reading JCAMP files

### DIFF
--- a/nmrglue/fileio/bruker.py
+++ b/nmrglue/fileio/bruker.py
@@ -5,6 +5,8 @@ files.
 """
 
 from __future__ import print_function, division
+import locale
+import io
 
 __developer_info__ = """
 Bruker file format information
@@ -2091,7 +2093,7 @@ def rm_dig_filter(
 
 # JCAMP-DX functions
 
-def read_jcamp(filename):
+def read_jcamp(filename, encoding=locale.getpreferredencoding()):
     """
     Read a Bruker JCAMP-DX file into a dictionary.
 
@@ -2103,6 +2105,8 @@ def read_jcamp(filename):
     ----------
     filename : str
         Filename of Bruker JCAMP-DX file.
+    encoding : str
+        Encoding of Bruker JCAMP-DX file. Defaults to the system default locale
 
     Returns
     -------
@@ -2121,7 +2125,7 @@ def read_jcamp(filename):
     """
     dic = {"_coreheader": [], "_comments": []}  # create empty dictionary
 
-    with open(filename, 'r') as f:
+    with io.open(filename, 'r', encoding=encoding) as f:
         while True:     # loop until end of file is found
 
             line = f.readline().rstrip()    # read a line


### PR DESCRIPTION
Allow to provide a list of possible encodings for reading JCAMP files,
and use the first encoding which doesn't raise an UnicodeDecodeError.
Suppress such errors, except when all provided encodings fail.
Keep the current behaviour by choosing the default encoding if no
encoding is specified.

I'm not sure if you want to pull this, but for my purposes this is easier and more futureproof than converting the JCAMP files on operating system level.