### PR TITLE
xcpy: Interfacing with external scripts from Topspin

### DIFF
--- a/nmrglue/util/xcpy.cfg
+++ b/nmrglue/util/xcpy.cfg
@@ -1,0 +1,4 @@
+[xcpy]
+python = python
+scripts = scripts
+nmrpipe = nmrpipe

--- a/nmrglue/util/xcpy.cfg
+++ b/nmrglue/util/xcpy.cfg
@@ -1,4 +1,0 @@
-[xcpy]
-python = python
-scripts = scripts
-nmrpipe = nmrpipe

--- a/nmrglue/util/xcpy.py
+++ b/nmrglue/util/xcpy.py
@@ -297,6 +297,10 @@ def show_config(filename, printing=True):
 
 
 def main():
+    """
+    The main function that gets called when xcpy is run
+
+    """
 
     if check_jython():
         toppath = topspin_location()

--- a/nmrglue/util/xcpy.py
+++ b/nmrglue/util/xcpy.py
@@ -126,26 +126,28 @@ def read_cfg(filename):
     return cpyname, scripts_location
 
 
-def write_cfg(outfile, infile):
+def write_cfg(outfile, infile=None):
     """
     Writes or overwrites a configuration file
 
     """
-    try:
-        cpyname, scripts_location = read_cfg(infile)
-    except:
-        if exists(infile):
-            errmsg = '''
-                The following configuration was found in the file {}:
+    if infile is not None:
+        try:
+            cpyname, scripts_location = read_cfg(infile)
+        except:
+            if exists(infile):
+                errmsg = '''
+                    The following configuration was found in the file {}:
 
-                {}
+                    {}
 
-                These settings are likely incorrect.
-                you can enter the correct settings at the next dialog box.
-                Press 'Close' to continue.
-                '''.format(infile, show_config(infile, printing=False))
-            MSG(errmsg)
-
+                    These settings are likely incorrect.
+                    you can enter the correct settings at the next dialog box.
+                    Press 'Close' to continue.
+                    '''.format(infile, show_config(infile, printing=False))
+                MSG(errmsg)
+            cpyname, scripts_location = "", ""
+    else:
         cpyname, scripts_location = "", ""
 
     cpyname, scripts_location = INPUT_DIALOG(

--- a/nmrglue/util/xcpy.py
+++ b/nmrglue/util/xcpy.py
@@ -105,3 +105,15 @@ def write_cfg(outfile, infile):
         MSG('Written Configuration file at: ' + outfile)
 
 
+def exists(filename, raise_error=False):
+    """
+    Checks whether a file exists either returns False or
+    raises an exception
+
+    """
+    if os.path.exists(filename):
+        return True
+    elif raise_error:
+        raise Exception('{} not found'.format(filename))
+    else:
+        return False

--- a/nmrglue/util/xcpy.py
+++ b/nmrglue/util/xcpy.py
@@ -72,3 +72,36 @@ def read_cfg(filename):
         cpyname, scripts_location = "", ""
 
     return cpyname, scripts_location
+
+
+def write_cfg(outfile, infile):
+    """
+    Writes or overwrites a configuration file
+
+    """
+    if infile is not None:
+        cpyname, scripts_location = read_cfg(infile)
+    else:
+        cpyname, scripts_location = "", ""
+
+    cpyname, scripts_location = INPUT_DIALOG(
+            "XCPy Configuration", 
+            "Please Click on OK to write this configuration.", 
+            ["CPython Executable", "CPython Scripts Location"], 
+            [cpyname, scripts_location], 
+            ["",""], 
+            ["1", "1"])
+
+    if not cpyname or not scripts_location: 
+        MSG("Invalid configartion specified. Config file not written")
+    else:
+        config = SafeConfigParser()
+        config.add_section('xcpy')
+        config.set('xcpy', 'cpython', cpyname)
+        config.set('xcpy', 'scripts_location', scripts_location)
+
+        with open(outfile, "w") as f:
+            config.write(f)
+        MSG('Written Configuration file at: ' + outfile)
+
+

--- a/nmrglue/util/xcpy.py
+++ b/nmrglue/util/xcpy.py
@@ -177,3 +177,35 @@ def verify_completion(process):
 
     else:
         return
+        
+    
+if __name__ == "__main__":
+    
+    # check whether running in Topspin/Jython and get the location if yes
+    if check_jython():
+        toppath = topspin_location()
+
+    # this is where the config file must be store
+    config_file = os.path.join(toppath, 'exp', 'stan', 'nmr', 'py', 'user', 'xcpy.cfg')
+
+    # get arguments passed to xcpy 
+    argv = sys.argv
+    if len(argv) == 1:
+        argv.append('--info')
+
+    # return docstring
+    if argv[1] in ['-i', '--info']: 
+        if len(argv) > 2:
+            MSG('Opening Documentation. All other options ignored. Press OK')
+        MSG(__doc__)
+
+    # check if configuration exists
+    elif not os.path.exists(config_file):
+        MSG("Configuration file does not exists. Will open an input dialog to write it")
+        write_cfg(config_file)
+
+    # if configuration settings are to be changed
+    elif argv[1] in ['-s', '--settings']:
+        if len(argv) > 2:
+            MSG('Opening Configuration Settings. All other options ignored. Press OK')
+        write_cfg(config_file, config_file)

--- a/nmrglue/util/xcpy.py
+++ b/nmrglue/util/xcpy.py
@@ -209,3 +209,35 @@ if __name__ == "__main__":
         if len(argv) > 2:
             MSG('Opening Configuration Settings. All other options ignored. Press OK')
         write_cfg(config_file, config_file)
+
+    else: 
+        if '--use-shell' in argv:
+            use_shell = True
+        else:
+            use_shell = False
+
+        if '--no-args' in argv:
+            pass_current_folder = False
+        else:
+            pass_current_folder = True
+
+        if '--dry-run' in argv:
+            dry = True
+        else:
+            dry = False
+
+        # read configuration
+        cpyname, folder = read_cfg(config_file)
+
+        # see if script is there and then run
+        if exists(cpyname) and exists(folder):
+            scriptname = os.path.join(folder, argv[1])
+
+            if exists(scriptname):
+                process = run(cpyname, scriptname, pass_current_folder, use_shell, dry)
+                verify_completion(process)
+            else:
+                scriptname = scriptname + '.py'
+                if exists(scriptname, raise_error=True):
+                    process = run(cpyname, scriptname, pass_current_folder, use_shell, dry)
+                    verify_completion(process)

--- a/nmrglue/util/xcpy.py
+++ b/nmrglue/util/xcpy.py
@@ -56,3 +56,19 @@ def topspin_location():
     # if all the above fail, there should be an exception raised and
     # the function should not return anything
     return toppath
+
+
+def read_cfg(filename):
+    """
+    Reads in the configuration file
+
+    """
+    config = SafeConfigParser()
+    try:
+        config.read(filename)
+        cpyname = config.get('xcpy', 'cpython')
+        scripts_location = config.get('xcpy', 'scripts_location')
+    except:
+        cpyname, scripts_location = "", ""
+
+    return cpyname, scripts_location

--- a/nmrglue/util/xcpy.py
+++ b/nmrglue/util/xcpy.py
@@ -64,12 +64,23 @@ def read_cfg(filename):
 
     """
     config = SafeConfigParser()
+    config.read(filename)
+
     try:
-        config.read(filename)
         cpyname = config.get('xcpy', 'cpython')
+    except:
+        cpyname = ""
+
+    try:
         scripts_location = config.get('xcpy', 'scripts_location')
     except:
-        cpyname, scripts_location = "", ""
+        scripts_location = ""
+
+    if cpyname:        
+        verify_python(cpyname)
+
+    if scripts_location:
+        exists(scripts_location, raise_error=True)
 
     return cpyname, scripts_location
 
@@ -125,12 +136,16 @@ def current_data():
     if executed when a data folder is open
 
     """
-    cd = CURDATA()
-    current_dir = os.path.join(cd[3], cd[0])
-    current_expno = cd[1]
-    current_procno = cd[2]
+    try:
+        cd = CURDATA()
+        current_dir = os.path.join(cd[3], cd[0])
+        current_expno = cd[1]
+        current_procno = cd[2]
+        return [current_dir, current_expno, current_procno]
 
-    return [current_dir, current_expno, current_procno]
+    except:
+        return []
+
 
 
 def run(cpython, script, pass_current_folder=True, use_shell=None, dry=None):

--- a/nmrglue/util/xcpy.py
+++ b/nmrglue/util/xcpy.py
@@ -160,3 +160,20 @@ def run(cpython, script, pass_current_folder=True, use_shell=None, dry=None):
         process.stdin.close()
     
     return process
+
+    
+def verify_completion(process):
+    """
+    Verify that the output is correct
+    """
+
+    if process is not None:
+        errmsg = [line for line in iter(process.stdout.readline, '')]
+
+        if not errmsg:
+            MSG('Script executed to completion')
+        else:
+            MSG(''.join(errmsg))
+
+    else:
+        return

--- a/nmrglue/util/xcpy.py
+++ b/nmrglue/util/xcpy.py
@@ -1,12 +1,53 @@
 """
 xcpy - interfaces with external programs from within Bruker-TopSpin
 
-SYNOPSIS
-    \t\txcpy
-    \t\txcpy [OPTIONS] 
-    \t\txcpy [OPTIONS] [SCRIPTNAME]
+USAGE
+xcpy
+xcpy [OPTIONS] 
+xcpy [OPTIONS] [SCRIPTNAME]
 
-Description
+INSTALLATION
+1. Copy (or symlink) this file to the following directory:
+<topspin_location>/exp/stan/nmr/py/user/
+2. If you now type 'xcpy' on the command line within Topspin,
+this documentation should pop up
+3. A configuration file needs to be written out so that xcpy
+knows the location of the CPython executable and a folder where
+the .py scripts are located. This can be done by 'xcpy -s'. This
+can be rewritten at any time point using the same command.  
+
+
+DESCRIPTION
+xcpy supports running external scripts via Jython (subprocess module) 
+that ships with Topspin. Currently, it allows only external CPython 
+programs to run. By default, it passes the current folder, expno and procno 
+to the external CPython program (if available).
+
+-h, --help: Brings up this docstring. Also brings it up when no other 
+\toption is given.
+
+-s, --settings: Opens a dialog to write out a configuration file. The 
+\tlocation of the Cpython executable and the folder where all scripts
+\tare located can be given. Use full path names for this, i.e., use 
+\t'/usr/bin/python3' for *nix instead of 'python3' or '~/folder/python3',
+\tand 'C:\python.exe' for Windows (note the .exe) extension. If the 
+\tconfiguration file already exists, the entries will be verified and 
+\tthe dialog will be populated with them if these are found to be correct.
+\tElse, an error message with the configuration file will be returned and
+\tthe dialogs will be kept empty.
+
+-c, --config: Prints contents of the configuration file, if it exists.
+\tIf no configuration file is found, it prints 'None'
+
+-d, --dry-run: Prints out the command that will be executed by the subprocess
+\tmodule if this option is not given.
+
+--no-args: Does not pass any arguments (current data folder, etc) to 
+\tthe external program
+
+--use-shell: Uses shell to run the subprocess command. By default, this is 
+\tnot used for *nix and turned on for Windows. [Warning: this is a known 
+\tsecurity risk, but seems to be the only way I can get this to work on Windows.
 
 """
 import sys
@@ -290,7 +331,7 @@ def main():
         else:
             pass_current_folder = True
 
-        if '--dry-run' in argv:
+        if '--dry-run' in argv or '-d' in argv:
             dry = True
         else:
             dry = False
@@ -309,7 +350,6 @@ def main():
                 process = run(cpyname, scriptname, pass_current_folder, use_shell, dry)
 
         verify_completion(process)
-
 
 
 if __name__ == "__main__":

--- a/nmrglue/util/xcpy.py
+++ b/nmrglue/util/xcpy.py
@@ -131,3 +131,32 @@ def current_data():
     current_procno = cd[2]
 
     return [current_dir, current_expno, current_procno]
+
+
+def run(cpython, script, pass_current_folder=True, use_shell=None, dry=None):
+    """
+    Runs a cpython script
+
+    """
+    if pass_current_folder == True:
+        cd = current_data()
+    else:
+        cd = []
+
+    if use_shell is None:
+        if os.name == 'nt':
+            use_shell = True
+        else:
+            use_shell = False
+
+    args = [cpython, script] + cd
+
+    if dry:
+        MSG('The following command will be executed: \n' + ' '.join(args))
+        process = None
+
+    else:
+        process = Popen(args, stdin=PIPE, stderr=STDOUT, shell=use_shell)
+        process.stdin.close()
+    
+    return process

--- a/nmrglue/util/xcpy.py
+++ b/nmrglue/util/xcpy.py
@@ -90,9 +90,9 @@ def write_cfg(outfile, infile):
     Writes or overwrites a configuration file
 
     """
-    if infile is not None:
+    try:
         cpyname, scripts_location = read_cfg(infile)
-    else:
+    except:
         cpyname, scripts_location = "", ""
 
     cpyname, scripts_location = INPUT_DIALOG(
@@ -192,9 +192,24 @@ def verify_completion(process):
 
     else:
         return
-        
+
+
+def verify_python(command):
+    """
+    Verify that the command to be saved in the config file points 
+    to a valid python executable
+    This is rudimentary! 
+
+    """
+    if not os.path.exists(command):
+        raise OSError('The command {} cannot be executed as the file does not exist'.format(command))
+
+    command = command.split(os.sep)[-1]
+    if command.lower().find('python') != 0:
+        raise OSError('Could not understand the command {}. This does not seem to be a valid python binary'.format(command))
+
     
-if __name__ == "__main__":
+def main():    
     
     # check whether running in Topspin/Jython and get the location if yes
     if check_jython():
@@ -245,14 +260,19 @@ if __name__ == "__main__":
         cpyname, folder = read_cfg(config_file)
 
         # see if script is there and then run
-        if exists(cpyname) and exists(folder):
-            scriptname = os.path.join(folder, argv[1])
+        scriptname = os.path.join(folder, argv[1])
 
-            if exists(scriptname):
+        if exists(scriptname):
+            process = run(cpyname, scriptname, pass_current_folder, use_shell, dry)
+        else:
+            scriptname = scriptname + '.py'
+            if exists(scriptname, raise_error=True):
                 process = run(cpyname, scriptname, pass_current_folder, use_shell, dry)
-                verify_completion(process)
-            else:
-                scriptname = scriptname + '.py'
-                if exists(scriptname, raise_error=True):
-                    process = run(cpyname, scriptname, pass_current_folder, use_shell, dry)
-                    verify_completion(process)
+
+        verify_completion(process)
+
+
+
+if __name__ == "__main__":
+    main()
+

--- a/nmrglue/util/xcpy.py
+++ b/nmrglue/util/xcpy.py
@@ -117,3 +117,17 @@ def exists(filename, raise_error=False):
         raise Exception('{} not found'.format(filename))
     else:
         return False
+
+
+def current_data():
+    """
+    Returns the current EXPNO and PROCNO open in Topspin,
+    if executed when a data folder is open
+
+    """
+    cd = CURDATA()
+    current_dir = os.path.join(cd[3], cd[0])
+    current_expno = cd[1]
+    current_procno = cd[2]
+
+    return [current_dir, current_expno, current_procno]

--- a/nmrglue/util/xcpy.py
+++ b/nmrglue/util/xcpy.py
@@ -1,0 +1,58 @@
+"""
+xcpy - interfaces with external programs from within Bruker-TopSpin
+
+SYNOPSIS
+    \t\txcpy
+    \t\txcpy [OPTIONS] 
+    \t\txcpy [OPTIONS] [SCRIPTNAME]
+
+Description
+
+"""
+import sys
+import os
+from ConfigParser import SafeConfigParser
+from subprocess import Popen, PIPE, STDOUT
+
+
+def check_jython():
+    """
+    Checks whether Jython is being used to run this script
+    from within Topspin
+
+    """
+    # some of the functions defined in the global namespace
+    # by Topspin which are also used by xcpy
+    topspin_inbuilts = ['MSG', 'INPUT_DIALOG', 'CURDATA']
+
+    g = globals().keys()
+    for function in topspin_inbuilts:
+        if function in g:
+            pass
+        else:
+            raise Exception('This file is meant to be executed \
+                             using Jython from within Topspin')
+    return True
+
+
+def topspin_location():
+    """
+    Gets Topspin home directory. Also serves to check
+    whether the script is being executed from within
+    Topspin or externally.
+
+    """
+    try:
+        # topspin >= 3.6
+        toppath = sys.getBaseProperties()["XWINNMRHOME"]
+    except:
+        try:
+            # topspin >= 3.1 and <= 3.5
+            toppath = sys.registry["XWINNMRHOME"]
+        except:
+            # topspin < 3.1
+            toppath = sys.getEnviron()["XWINNMRHOME"]
+    
+    # if all the above fail, there should be an exception raised and
+    # the function should not return anything
+    return toppath

--- a/nmrglue/util/xcpy_test.py
+++ b/nmrglue/util/xcpy_test.py
@@ -11,17 +11,18 @@ def main():
 
     try:
         name, curdir, curexpno, curprocno = sys.argv
-        message = f"""
-        Welcome to Python {python}.
-        The current directory is set to {curdir}
-        EXPNO {curexpno} is currently open at PROCNO {curprocno}
-        """
+        message = """
+        Welcome to Python {}.
+        The current directory is set to {}
+        EXPNO {} is currently open at PROCNO {}
+        """.format(python, curdir, curexpno, curprocno)
 
     except ValueError:
-        message = f"""
-        Welcome to Python {python}.
-        No directory is currently open.
-        """
+        message = """
+        Welcome to Python {}.
+        No directory is currently open, 
+        or none was passed on to this script.
+        """.format(python)
 
     print(message)
 


### PR DESCRIPTION
Bruker-Topspin now being freely [available](https://www.bruker.com/service/support-upgrades/software-downloads/nmr/free-topspin-processing/nmr-topspin-license-for-academia.html) under an academic licence, this is a feature request that comes up often for me, and has [popped](https://groups.google.com/forum/#!topic/nmrglue-discuss/FPxhw4M6OLs) up on the `nmrglue-discuss` group as well. The file `xcpy.py`, which is included in the `nmrglue/util` folder, will allow the use of nmrglue (and any other cpython script) from within Topspin. It is a lightly polished version of what has been sitting in one of my repositories for sometime now, and takes some suggestions from the nmrglue-discuss thread. This should go nicely with the ability of nmrglue to read and write (#85, #88) bruker datasets, and also with the philosophy of nmrglue of being the 'glue'. I am including a simple "Hello World" script as well (xcpy_test.py), but some real world examples can be found [here](https://github.com/kaustubhmote/pulseseq/tree/master/python/cpython).

The documentation on how to use this file are given in the file docstring itself. The TLDR version is: 
Copy or symlink `xcpy.py` to the `<topspin>/exp/stan/nmr/py/user` directory, where <topspin> is the directory where your topspin is located. If you now type `xcpy` or `xcpy -h` from within Topspin, the documentation should pop up and is hopefully self-explanatory regarding the various options and initial set up.   

A simple GIF on how this should look like:

![xcpy](https://user-images.githubusercontent.com/7735086/60869506-baff0480-a24c-11e9-92d2-63d0e7fec558.gif)

This approach is, of course, not restricted to `nmrglue`; other programs like `nmrpipe`, `matnmr`, etc can all be accessed from within Topspin in a similar fashion (xcpy uses the `subprocess` module of the internal Jython to call an external script). I am inclined to start with just this, and see whether any bugs pop up before including other things in there. Currently, this is tested with Linux and Windows, and Topspin 3.6 and 4.0. 