### PR TITLE
Additional options for autops

### DIFF
--- a/nmrglue/process/proc_autophase.py
+++ b/nmrglue/process/proc_autophase.py
@@ -14,7 +14,7 @@ import scipy.optimize
 from .proc_base import ps
 
 
-def autops(data, fn, p0=0.0, p1=0.0):
+def autops(data, fn, p0=0.0, p1=0.0, return_phases=False, **kwargs):
     """
     Automatic linear phase correction
 
@@ -43,11 +43,14 @@ def autops(data, fn, p0=0.0, p1=0.0):
         }[fn]
 
     opt = [p0, p1]
-    opt = scipy.optimize.fmin(fn, x0=opt, args=(data, ))
+    opt = scipy.optimize.fmin(fn, x0=opt, args=(data,), **kwargs)
 
     phasedspc = ps(data, p0=opt[0], p1=opt[1])
 
-    return phasedspc
+    if return_phases:
+        return phasedspc, opt
+    else:
+        return phasedspc
 
 
 def _ps_acme_score(ph, data):
@@ -57,7 +60,7 @@ def _ps_acme_score(ph, data):
 
     Parameters
     ----------
-    pd : tuple
+    ph : tuple
         Current p0 and p1 values
     data : ndarray
         Array of NMR data.

--- a/nmrglue/process/proc_autophase.py
+++ b/nmrglue/process/proc_autophase.py
@@ -29,6 +29,20 @@ def autops(data, fn, p0=0.0, p1=0.0, return_phases=False, **kwargs):
         Initial zero order phase in degrees.
     p1 : float
         Initial first order phase in degrees.
+    return_phases : Bool
+        returns a list of optimized values of phases [p0, p1] in addition
+        to the phased data
+    kwargs : additional key-word arguments to be passed to the solver
+        The are documented at the following link: 
+        https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.fmin.html
+        Some of the more useful ones for this use case:
+        disp : Bool  
+            Turns on or off the printing of convergence messeges
+            By default, this is set to True.
+        ftol : float
+            Absolute error in fn between iterations that is acceptable for
+            convergence. The default is 1e-4.
+        
 
     Returns
     -------

--- a/nmrglue/process/proc_autophase.py
+++ b/nmrglue/process/proc_autophase.py
@@ -98,7 +98,7 @@ def _ps_acme_score(ph, data):
 
     p = 1000 * pfun
 
-    return h1s + p
+    return (h1s + p) / data.shape[-1] / np.max(data)
 
 
 def _ps_peak_minima_score(ph, data):


### PR DESCRIPTION
This PR does 3 things to the `autops` function:

1. Allows an optional `return_phases` argument. If set to `True`, the optimized phases will be returned. By default, this is set to `False`.
2. Allows additional (optional) keyword arguments to be passed to the `scipy.optimize.fmin`. The default options work fine most of the time for `autops`, but this way, one has the option to turn off the (sometimes irritating) convergence messages (using `disp=False`). Also `maxiter` and `ftol` might  be useful in some cases. The complete list of options is documented [here](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.fmin.html).
3.  "Normalizes"  the return value of the "acme" function to a reasonable number. The current return value is very high and sometimes causes convergence issues. This should fix #102. 

None of the above should change the default behavior of the `autops` function and all changes are backward compatible. This PR has some overlap with #48, but that seems to have stalled, and I am not implementing any of the changes proposed to the "acme" function itself.
