### PR TITLE
Updates to the documentation

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -14,7 +14,7 @@ Requirements
 ------------
 
 
-nmrglue dependes on the following open-source packages for scientific computing
+nmrglue depends on the following open-source packages for scientific computing
 in the Python ecosystem.
 
 +------------+------------+---------------------------------------+
@@ -22,7 +22,7 @@ in the Python ecosystem.
 +============+============+=======================================+
 | Python     | 2.7.9+     | Version 3 and above are recommended   |
 +------------+------------+---------------------------------------+
-| Numpy      | 1.21+      | Required for all basic data types     |
+| Numpy      | 1.16+      | Required for all basic data types     |
 +------------+------------+---------------------------------------+
 | Scipy      | 0.16+      | Required for processing functions     |
 +------------+------------+---------------------------------------+
@@ -30,7 +30,7 @@ in the Python ecosystem.
 |            |            | such as interactive phase correction  |                           
 +------------+------------+---------------------------------------+
 
-Additionally, an interactive environment such as `IPython <http://ipython.org/>`_, (available via several distributions such as `Jupyterlab <https://jupyterlab.readthedocs.io/en/stable/>`_, `Spider <https://www.spyder-ide.org/>`_, `Google Colaboratory <https://colab.research.google.com/>`_, etc.) is highly recommended. A easy way of obtaining and installing these packages is to use a Python distribution which provides these packages, such as `EPD <http://www.enthought.com/products/epd.php>`_ or `Conda <https://www.anaconda.com/>`_. Detailed information on `installing a Scipy stack <http://scipy.github.com/install.html>`_ is available. Note that although the nmrglue codebase remains compatible with Python 2.7+, Python 2, along with Numpy, Scipy and Matplotlib versions that are compatible with it, are `no longer actively maintained <https://www.python.org/doc/sunset-python-2/>`_. Hence, we recommend that Python 3 be used for all new code. 
+Additionally, an interactive environment such as `IPython <http://ipython.org/>`_, (available via several distributions such as `Jupyterlab <https://jupyterlab.readthedocs.io/en/stable/>`_, `Spyder <https://www.spyder-ide.org/>`_, `Google Colaboratory <https://colab.research.google.com/>`_, etc.) is highly recommended. An easy way of obtaining and installing these packages is to use a Python distribution which provides these packages, such as `Anaconda/Miniconda <https://www.anaconda.com/>`_. Detailed information on `installing a Scipy stack <https://scipy.org/install.html>`_ is available. Note that although the nmrglue codebase remains compatible with Python 2.7+, Python 2, along with Numpy, Scipy and Matplotlib versions that are compatible with it, are `no longer actively maintained <https://www.python.org/doc/sunset-python-2/>`_. Hence, we recommend that Python 3 be used for all new code. 
 
 
 Platform Independent Installation
@@ -59,7 +59,7 @@ distribution and run::
 Windows Installation
 --------------------
 
-Download the binary installer and run it.
+Installation of the Scipy stack via a distribution such as `Anaconda/Miniconda`_ is recommended. nmrglue can then be installed using pip, as described above. Alternately, you can download the binary installer and run it.
 
 Installing from source code
 ---------------------------

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -13,14 +13,39 @@ Windows.
 Requirements
 ------------
 
-nmrglue requires `NumPy <http://numpy.scipy.org>`_ and 
-`SciPy <http://www.scipy.org>`_ to be installed. The 
-`matplotlib <http://matplotlib.org/>`_ and `IPython <http://ipython.org/>`_
-packages are highly recommended.  A easy way of obtaining 
-and installing these packages is to use a Python distribution which provides 
-these packages, such as `EPD <http://www.enthought.com/products/epd.php>`_.  
-Detailed information on 
-`installing a Scipy stack <http://scipy.github.com/install.html>`_ is available.
+
+nmrglue dependes on the following open-source packages for scientific computing
+in the Python ecosystem.
+
++------------+------------+---------------------------------------+
+| Package    | Version    | Details                               |
++============+============+=======================================+
+| Python     | 2.7.9+     | Version 3 and above are recommended   |
++------------+------------+---------------------------------------+
+| Numpy      | 1.21+      | Required for all basic data types     |
++------------+------------+---------------------------------------+
+| Scipy      | 0.16+      | Required for processing functions     |
++------------+------------+---------------------------------------+
+| Matplotlib | 2.2.3+     | Optional, required for some functions |  
+|            |            | such as interactive phase correction  |                           
++------------+------------+---------------------------------------+
+
+Additionally, an interactive environment such as `IPython <http://ipython.org/>`_, (available via several distributions such as `Jupyterlab <https://jupyterlab.readthedocs.io/en/stable/>`_, `Spider <https://www.spyder-ide.org/>`_, `Google Colaboratory <https://colab.research.google.com/>`_, etc.) is highly recommended. A easy way of obtaining and installing these packages is to use a Python distribution which provides these packages, such as `EPD <http://www.enthought.com/products/epd.php>`_ or `Conda <https://www.anaconda.com/>`_. Detailed information on `installing a Scipy stack <http://scipy.github.com/install.html>`_ is available. Note that although the nmrglue codebase remains compatible with Python 2.7+, Python 2, along with Numpy, Scipy and Matplotlib versions that are compatible with it, are `no longer actively maintained <https://www.python.org/doc/sunset-python-2/>`_. Hence, we recommend that Python 3 be used for all new code. 
+
+
+Platform Independent Installation
+---------------------------------
+
+nmrglue is available for installation via the Python Package Index. The latest
+stable version can be installed using::
+    
+    $ python -m pip install nmrglue
+
+The current development version can be installed directly from GitHub using::
+
+    $ python -m pip install git+git://github.com/jjhelmus/nmrglue
+
+This requires `git` to be installed and available.
 
 
 Unix/OSX Installation

--- a/doc/source/reference/bruker.rst
+++ b/doc/source/reference/bruker.rst
@@ -19,6 +19,7 @@ These are functions which are targetted for users of nmrglue.
     read
     write
     read_pdata
+    write_pdata
     remove_digital_filter
     read_lowmem
     write_lowmem

--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -60,3 +60,4 @@ util modules
     :maxdepth: 1
     
     misc
+    xcpy

--- a/doc/source/reference/sparky.rst
+++ b/doc/source/reference/sparky.rst
@@ -16,6 +16,7 @@ User Functions
 
     read
     write
+    read_savefile
     read_lowmem
     write_lowmem
     make_uc

--- a/doc/source/reference/xcpy.rst
+++ b/doc/source/reference/xcpy.rst
@@ -1,0 +1,73 @@
+nmrglue.misc.xcpy
+=================
+
+This module is intended for use with the Bruker Topspin software. 
+It runs external scripts via Jython (subprocess module) that ships with Topspin. 
+Currently, it allows only external CPython programs to run. By default, it passes
+the current folder, expno and procno to the external CPython program (if available).
+For an example of how this should look like in practice, see 
+`PR #103 <https://github.com/jjhelmus/nmrglue/pull/103>`_.
+
+A test script `xcpy_test.py` is provided in the same folder. This can be used to test 
+the setup. After copying over xcpy.py and xcpy.test to the prescribed locations (see below), 
+the output should look something like this:
+
+.. image:: https://user-images.githubusercontent.com/7735086/60869506-baff0480-a24c-11e9-92d2-63d0e7fec558.gif
+
+
+Usage
+-----
+.. code-block:: 
+
+  xcpy
+  xcpy [OPTIONS]
+  xcpy [OPTIONS] [SCRIPTNAME]
+
+
+Installation
+------------
+1. Copy (or symlink) this file to the following directory:
+<topspin_location>/exp/stan/nmr/py/user/
+2. If you now type 'xcpy' on the command line within Topspin,
+this documentation should pop up
+3. A configuration file needs to be written out so that xcpy
+knows the location of the CPython executable and a folder where
+the .py scripts are located. This can be done by 'xcpy -s'. This
+can be rewritten at any time point using the same command.
+
+
+Description
+-----------
+
+
+Options
+-------
+1. `-h, --help`: Brings up this document. Also brings it up when no other
+option is given.
+
+2. `-s, --settings`: Opens a dialog to write out a configuration file. The
+location of the Cpython executable and the folder where all scripts
+are located can be given. Use full path names for this, i.e., use
+'/usr/bin/python3' for \*nix instead of 'python3' or '~/folder/python3',
+and 'C:\python.exe' for Windows (note the .exe) extension. If the
+configuration file already exists, the entries will be verified and
+the dialog will be populated with them if these are found to be correct.
+Else, an error message with the configuration file will be returned and
+the dialogs will be kept empty.
+
+3. `-n, --name`: Opens a dialog box to give the path of a script to be run
+
+4. `-c, --config`: Prints contents of the configuration file, if it exists.
+If no configuration file is found, it prints 'None'
+
+5. `-d, --dry-run`: Prints out the command that will be executed by the subprocess
+module if this option is not given.
+
+6. `--no-args`: Does not pass any arguments (current data folder, etc) to
+the external program
+
+7. `--use-shell`: Uses shell to run the subprocess command. By default, this is
+not used for \*nix, but is used for Windows. (*Warning*: this is a known
+security risk and users are advised to be careful with their input while using this
+option)
+

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -69,7 +69,7 @@ Examining the data object in more detail:
 
 We can see that this is a two dimensional data set with 1500 complex points
 in the direct dimension and 332 points in the indirect dimension.  nmrglue 
-takes care of converting the raw data in the file into an array of appropiate 
+takes care of converting the raw data in the file into an array of appropriate 
 type, dimensionality, and quadrature.  For complex data the last axis, 
 typically the direct dimension, is converted to a complex data type.  The other
 axes are not converted.
@@ -104,9 +104,9 @@ of additional parameters.
 Some file formats describe well the spectral data, listing a large number of 
 parameters, other only a few.  In addition, different formats express 
 parameters in different units and under different names.  For users who are 
-familar with the specific file format or are working with only a single file
+familiar with the specific file format or are working with only a single file
 type, this is not a problem; the dictionary allows direct access to these
-parameters. If a more uniform listing of spectal parameters is desired, the
+parameters. If a more uniform listing of spectral parameters is desired, the
 ``guess_udic`` function can be used to create a 'universal' dictionary.
 
     >>> udic = ng.pipe.guess_udic(dic,data)
@@ -127,7 +127,7 @@ car         Carrier frequency in Hz.
 complex     True for complex data, False for magnitude data.
 encoding    How the data is encoded, 'states', 'tppi', etc.
 freq        True for frequency domain data, False for time domain.
-label       String descriping the axis name.
+label       String describing the axis name.
 obs         Observation frequency in MHz.
 size        Dimension size (R|I for last axis, R+I for others)
 sw          Spectral width in Hz.
@@ -302,7 +302,7 @@ But this check can be by-passed with the overwrite parameter:
 The unit_conversion object
 ==========================
 
-Eariler we used the array index values for slicing the numpy array.  For 
+Earlier we used the array index values for slicing the numpy array.  For 
 reference your data in more common NMR units nmrglue provides the 
 ``unit_coversion`` object.  Use the ``make_uc`` function to create a 
 ``unit_conversion`` object:
@@ -312,7 +312,7 @@ reference your data in more common NMR units nmrglue provides the
     >>> uc1 = ng.pipe.make_uc(dic,data,dim=1)
 
 We now have unit conversion objects for both axes in the 2D spectrum.  We can
-use these objects to determind the nearest point for a given unit:
+use these objects to determined the nearest point for a given unit:
 
     >>> uc0("100.0 ppm")
     1397
@@ -358,7 +358,7 @@ module.  For example to convert a 2D NMRPipe file to a Sparky file:
 
 Here we opened the NMRPipe file *test.ft2* , created a new ``converter`` object
 and loaded it with the NMRPipe data.  The ``converter`` is then used to generate
-the Sparky parameter dictionary and a data array appropiate for Sparky data 
+the Sparky parameter dictionary and a data array appropriate for Sparky data 
 which is written to *sparky_file.ucsf*.
 All type conversions, and sign manipulation of the data array is performed 
 internally by the ``converter`` object.  In addition new dictionaries are 
@@ -380,9 +380,9 @@ small portion must be examined for viewing or processing.  With this in mind
 nmrglue provides methods to read only a portions of NMR data from files when
 it is required.  This is accomplished by creating a new object which look
 very similar to numpy array but does not load data into memory.  
-Rather when a particular slice is requested the the object opens the 
+Rather when a particular slice is requested the object opens the 
 necessary file(s), reads in the data and returns to the user a numpy 
-array with the data.  In addition these objects have tranpose and swapaxes
+array with the data.  In addition these objects have transpose and swapaxes
 method and can be iterated over just as numpy arrays but without using 
 large amounts of memory.  The only limitation of these objects is that they 
 do not support assignment, so a slice must be taken before changing the value
@@ -434,7 +434,7 @@ functions users might find useful.  nmrglue provides a number of common
 NMR functions in the :ref:`proc_base` module, baseline related functions
 in :ref:`proc_bl`, and linear prediction functions in the :ref:`proc_lp`
 module.  For example we perform some simple processing on our 2D NMRPipe file 
-(output supressed):
+(output suppressed):
 
     >>> dic,data = ng.pipe.read("test.fid")
     >>> ng.proc_base.ft(data)
@@ -447,7 +447,7 @@ update the spectral parameter associated with the data.  Because these
 values are key when examining NMR data we want functions which take into 
 account these parameter while processing.  nmrglue provides the 
 :ref:`pipe_proc` module for processing NMRPipe data while updating the
-spectral properties simulatanously.  Additional modules for processing 
+spectral properties simultaneously.  Additional modules for processing 
 other file format are being developed.  Using ``pipe_proc`` is similar to
 using NMRPipe itself.  For example to process the sample 2D NMRPipe file:
 
@@ -481,7 +481,7 @@ such processing but development of these is planned.
 An example of processing a 3D NMRPipe file using a ``iter3D`` object can be 
 found in :ref:`process_pipe_3d`.
 
-Additonal examples showing how to use nmrglue to process NMR data can be
+Additional examples showing how to use nmrglue to process NMR data can be
 found in the :ref:`processing_examples`.
 
 
@@ -491,9 +491,9 @@ Using matplotlib to create figures
 A number of python plotting libraries exist which can be used in conjunction
 with nmrglue to produce publication quality figures.  matplotlib is one of
 the more popular libraries and has the ability to output to a number of 
-hardcopy formats as well as offering a robust interactive environment.  When
+hard copy formats as well as offering a robust interactive environment.  When
 using matplotlib interactively use of `ipython`_
-or a similar shell is recommeneded although the standard python shell can be 
+or a similar shell is recommended although the standard python shell can be 
 used.
 
     >>> import matplotlib.pyplot as plt
@@ -511,7 +511,7 @@ figure is saved as ``plot_1d.png``.
     :scale: 50
 
 
-Alternately, the `object-oriented interface <https://matplotlib.org/tutorials/introductory/lifecycle.html>`_  from matploltib can be used. This is especially useful when make more complicated plots. The above example would look something like this:
+Alternately, the `object-oriented interface <https://matplotlib.org/tutorials/introductory/lifecycle.html>`_  from matplotlib can be used. This is especially useful when make more complicated plots. The above example would look something like this:
 
     >>> import matplotlib.pyplot as plt
     >>> dic, data = ng.pipe.read("test.ft")
@@ -550,7 +550,7 @@ by using Python build in help system:
     >>> help(ng.pipe.read)
     
 A number of :ref:`examples-index` using nmrglue to interact with 
-NMR data are avilable. Finally documentation for the following packages
+NMR data are available. Finally documentation for the following packages
 might be useful to users of nmrglue:
 
 * `numpy <https://www.numpy.org/>`_ 

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -14,7 +14,7 @@ understanding of python is assumed which can be obtained by reading some
 of the `python documentation <http://docs.python.org/>`_.  The examples in 
 this tutorial can be run interactively from the python shell but the use of an
 enhanced python shell which provides non-blocking control of GUI threads, 
-for example  `ipython <http://ipython.scipy.org>`_, is 
+for example  `ipython <http://www.ipython.org>`_, is 
 recommended when trying the examples which use matplotlib.  The sample data
 using in this tutorial is 
 `available <http://code.google.com/p/nmrglue/downloads/list>`_ is you wish to 
@@ -256,7 +256,7 @@ The `numpy documentation <https://numpy.org/doc/>`_ has additional
 information on the 
 `array <https://numpy.org/doc/stable/reference/generated/numpy.array.html>`_ 
 object.  In addition by combining nmrglue with 
-`numpy <https://www.numpy.org/>`_ and/or `scipy <http://www.scipy.org/>`_
+`numpy <https://www.numpy.org/>`_ and/or `scipy <https://www.scipy.org/>`_
 more complex data manipulation and calculation can be performed.  Later we
 will show how these modules are used to create a full suite of processing 
 functions.
@@ -428,7 +428,7 @@ Processing data
 
 With NMR spectral data being stored as a numpy array a number of linear 
 algebra and signal processing functions can be applied to the data.  The 
-functions in the `numpy <https://numpy.org/>`_
+functions in the `numpy <https://www.numpy.org/>`_
 and `scipy <https://www.scipy.org/>`_ modules offer a number of processing
 functions users might find useful.  nmrglue provides a number of common
 NMR functions in the :ref:`proc_base` module, baseline related functions
@@ -494,33 +494,41 @@ the more popular libraries and has the ability to output to a number of
 hardcopy formats as well as offering a robust interactive environment.  When
 using matplotlib interactively use of `ipython`_
 or a similar shell is recommeneded although the standard python shell can be 
-used.  For example to create a simple plot of a 1D spectrum (if the ipython
-shell is used for this example use the ``-pylab`` switch) :
+used.
 
-    >>> import pylab
-    >>> dic,data = ng.pipe.read("test.ft")
-    >>> pylab.plot(data)
+    >>> import matplotlib.pyplot as plt
+    >>> dic, data = ng.pipe.read("test.ft")
+    >>> plt.plot(data)
     [<matplotlib.lines.Line2D object at 0x8754fd0>]
-    >>> pylab.savefig("plot_1d.png")
+    >>> plt.savefig("plot_1d.png")
 
 
-Here we have loaded the pylab module from matplotlib and used it to plot the
-1D frequency domain data of a model protein.  The resulting figure is saved
-as ``plot_1d.png``.
+Here we have loaded the pyplot module from matplotlib (aliased as plt), and 
+used it to plot the 1D frequency domain data of a model protein.  The resulting 
+figure is saved as ``plot_1d.png``.
 
 .. image:: plot_1d.png
     :scale: 50
 
+
+Alternately, the `object-oriented interface <https://matplotlib.org/tutorials/introductory/lifecycle.html>`_  from matploltib can be used. This is especially useful when make more complicated plots. The above example would look something like this:
+
+    >>> import matplotlib.pyplot as plt
+    >>> dic, data = ng.pipe.read("test.ft")
+    >>> fig, ax = plt.subplots()
+    >>> ax.plot(data)
+    >>> fig.savefig("plot_1d.png")
+
 A contour plot of 2D data can created in a similar manner:
 
-    >>> pylab.cla()
-    >>> dic,data = ng.pipe.read("test.ft2")
-    >>> cl = [30000*1.2**x for x in range(20)]
-    >>> pylab.contour(data,cl)
+    >>> dic, data = ng.pipe.read("test.ft2")
+    >>> cl = [30000 * 1.2 ** x for x in range(20)]
+    >>> fig, ax = plt.subplots()
+    >>> ax.contour(data, cl)
     <matplotlib.contour.ContourSet instance at 0x151e2f80>
-    >>> pylab.show()
+    >>> plt.show()
 
-The ``show()`` method raises an an interactive window for examining the plot:
+The ``plt.show()`` method raises an an interactive window for examining the plot:
 
 .. image:: screenshot.jpg
     :scale: 50
@@ -545,10 +553,10 @@ A number of :ref:`examples-index` using nmrglue to interact with
 NMR data are avilable. Finally documentation for the following packages
 might be useful to users of nmrglue:
 
-* `numpy <https://numpy.org/>`_ 
+* `numpy <https://www.numpy.org/>`_ 
 * `scipy <https://www.scipy.org/>`_ 
 * `matplotlib <https://matplotlib.org/>`_
-* `h5py <http://h5py.org/>`_
+* `h5py <https://h5py.org/>`_
 
 .. _below:
 

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -26,7 +26,9 @@ Reading NMR files
 =================
 
 nmrglue can read and write to a number of common NMR file formats.  To see 
-how simple this can be let's read a 2D NMRPipe file.
+how simple this can be let's read a 2D NMRPipe file. (Note: If you need an example 
+dataset, use the one provided `here <https://github.com/jjhelmus/nmrglue/tree/master/tests/pipe_proc_tests>`_, and replace ``test.fid`` or ``test.ft`` with the names
+of the files ending in ``.fid`` or ``.dat``).
 
     >>> import nmrglue as ng
     >>> dic,data = ng.pipe.read("test.fid")
@@ -37,18 +39,24 @@ files and all of these modules have a ``read`` function which opens a file
 or directory containing NMR data, reads in any necessary information, and loads 
 the spectral data into memory.  The ``read`` function returns a 2-tuple 
 containing a python dictionary with file and spectral parameters and a 
-`numpy <http://numpy.scipy.org/>`_ array object containing the numeric 
+`numpy <https://www.numpy.org/>`_ array object containing the numeric 
 spectral data.  Currently the following file formats are supported by nmrglue
 with the associated module:
 
-======  ========================
-Module  File Format
-======  ========================
-bruker  Bruker
-pipe    NMRPipe
-sparky  Sparky
-varian  Varian/Agilent
-======  ========================
+=======  ======================== ==================
+Module   File Format              Reference 
+=======  ======================== ==================
+bruker   Bruker                   https://www.bruker.com/service/information-communication/user-manuals/nmr.html 
+pipe     NMRPipe                  https://www.ibbr.umd.edu/nmrpipe/index.html
+sparky   Sparky                   https://nmrfam.wisc.edu/nmrfam-sparky-distribution/
+varian   Varian/Agilent           
+rnmrtk   Rowland NMR Toolkit      https://rnmrtk.uchc.edu/rnmrtk/RNMRTK.html
+jcampdx  JCAMP-DX                 http://www.jcamp-dx.org/
+nmrml    NMR Markup Language      https://github.com/nmrML/nmrML
+simpson  Simpson                  https://inano.au.dk/about/research-centers/nmr/software/simpson/
+tecmag   Technology for Magnetic  https://www.tecmag.com/
+         Resonance
+=======  ======================== ==================
 
 Examining the data object in more detail:
 
@@ -244,11 +252,11 @@ Or a region:
     >>> data[9].imag
     array([ 1.,  1.,  1., ...,  1.,  1.,  1.], dtype=float32)
 
-The `numpy documentation <http://docs.scipy.org/doc/>`_ has additional 
+The `numpy documentation <https://numpy.org/doc/>`_ has additional 
 information on the 
-`array <http://docs.scipy.org/doc/numpy/reference/arrays.ndarray.html>`_ 
+`array <https://numpy.org/doc/stable/reference/generated/numpy.array.html>`_ 
 object.  In addition by combining nmrglue with 
-`numpy <http://numpy.scipy.org/>`_ and/or `scipy <http://www.scipy.org/>`_
+`numpy <https://www.numpy.org/>`_ and/or `scipy <http://www.scipy.org/>`_
 more complex data manipulation and calculation can be performed.  Later we
 will show how these modules are used to create a full suite of processing 
 functions.
@@ -420,8 +428,8 @@ Processing data
 
 With NMR spectral data being stored as a numpy array a number of linear 
 algebra and signal processing functions can be applied to the data.  The 
-functions in the `numpy <http://numpy.scipy.org/>`_
-and `scipy <http://www.scipy.org/>`_ modules offer a number of processing
+functions in the `numpy <https://numpy.org/>`_
+and `scipy <https://www.scipy.org/>`_ modules offer a number of processing
 functions users might find useful.  nmrglue provides a number of common
 NMR functions in the :ref:`proc_base` module, baseline related functions
 in :ref:`proc_bl`, and linear prediction functions in the :ref:`proc_lp`
@@ -521,7 +529,7 @@ The ``show()`` method raises an an interactive window for examining the plot:
 matplotlib can be used to create more complicated figures with annotations, ppm
 axes and more.  The :ref:`plotting_examples` and :ref:`interactive_examples`
 showcase some some of this functionality.  For additional information see the
-`matplotlib webpage <http://matplotlib.sourceforge.net/>`_
+`matplotlib webpage <https://www.matplotlib.org>`_
 
 
 Additional resources
@@ -537,10 +545,10 @@ A number of :ref:`examples-index` using nmrglue to interact with
 NMR data are avilable. Finally documentation for the following packages
 might be useful to users of nmrglue:
 
-* `numpy <http://numpy.scipy.org/>`_ 
-* `scipy <http://www.scipy.org/>`_ 
-* `matplotlib <http://matplotlib.sourceforge.net/>`_
-* `h5py <http://code.google.com/p/h5py/>`_
+* `numpy <https://numpy.org/>`_ 
+* `scipy <https://www.scipy.org/>`_ 
+* `matplotlib <https://matplotlib.org/>`_
+* `h5py <http://h5py.org/>`_
 
 .. _below:
 


### PR DESCRIPTION
This PR updates the documentation at these places:
1. New functions in `fileio.simpson.py` and `fileio.bruker.py` catalogued
2. A new file for documenting `misc.xcpy.py`
3. Updated installation instructions and requirements (`install.rst`) 
4. Updated `tutorial.rst` (correct links, more information on filetypes that nmrglue can handle)
5. Updated instructions to use matplotllib in `tutorial.rst`