### PR TITLE
Fix bug when passing specific procs_file in read_fid or read_pdata (Bruker imports)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ examples/jbnmr_examples/s7-s9_s3e_processing/procpar
 .project
 .pydevproject
 *.prefs
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ examples/bruker_data/expnmr_00001*
 examples/bruker_data/test.fid
 examples/bruker_data/test.ft2
 
+
 # JBNMR Examples
 examples/jbnmr_examples/*/*.fid
 examples/jbnmr_examples/*/*.ft2
@@ -61,11 +62,8 @@ examples/jbnmr_examples/s10_covariance_processing/test.ft
 examples/jbnmr_examples/s7-s9_s3e_processing/fid
 examples/jbnmr_examples/s7-s9_s3e_processing/procpar
 
+
 #Eclipse PyDev
 .project
 .pydevproject
 *.prefs
-
-#Pycharm dev
-.idea
-*.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,6 @@ examples/bruker_data/expnmr_00001*
 examples/bruker_data/test.fid
 examples/bruker_data/test.ft2
 
-
 # JBNMR Examples
 examples/jbnmr_examples/*/*.fid
 examples/jbnmr_examples/*/*.ft2
@@ -62,9 +61,11 @@ examples/jbnmr_examples/s10_covariance_processing/test.ft
 examples/jbnmr_examples/s7-s9_s3e_processing/fid
 examples/jbnmr_examples/s7-s9_s3e_processing/procpar
 
-
 #Eclipse PyDev
 .project
 .pydevproject
 *.prefs
+
+#Pycharm dev
 .idea
+*.egg-info

--- a/nmrglue/fileio/bruker.py
+++ b/nmrglue/fileio/bruker.py
@@ -597,7 +597,7 @@ def read_procs_file(dir='.', procs_files=None):
         Dictionary of Bruker parameters.
     """
 
-    if not procs_files:
+    if procs_files is None:
 
         # Reading standard procs files
         procs_files = []
@@ -1223,10 +1223,9 @@ def read_pdata(dir=".", bin_files=None, procs_files=None, read_procs=True,
         else:
             raise IOError("No Bruker binary file could be found in %s" % (dir))
 
-    for f in bin_files[1:]:
+    for f in bin_files.copy():
         if not os.path.isfile(os.path.join(dir, f)):
-            bin_files = [bin_files[0]]
-            break
+            bin_files.remove(f)
 
     if read_procs:
         # read the procs_files and add to the dictionary

--- a/nmrglue/fileio/bruker.py
+++ b/nmrglue/fileio/bruker.py
@@ -552,7 +552,7 @@ def read_acqus_file(dir='.', acqus_files=None):
         Directory to read from.
     acqus_files : list, optional
         List of filename(s) of acqus parameter files in directory. None uses
-        standard files.
+        standard files. If filename(s) contains a full absolute path, dir is not used.
 
     Returns
     -------
@@ -562,15 +562,20 @@ def read_acqus_file(dir='.', acqus_files=None):
     if acqus_files is None:
         acqus_files = []
         for f in ["acqus", "acqu2s", "acqu3s", "acqu4s"]:
-            if os.path.isfile(os.path.join(dir, f)):
-                acqus_files.append(f)
+            fp = os.path.join(dir, f)
+            if os.path.isfile(fp):
+                acqus_files.append(fp)
 
     # create an empty dictionary
     dic = dict()
 
     # read the acqus_files and add to the dictionary
     for f in acqus_files:
-        dic[f] = read_jcamp(os.path.join(dir, f))
+        if not os.path.isfile(f):
+            f = os.path.join(dir, f)
+        acqu = os.path.basename(f)
+        dic[acqu] = read_jcamp(f)
+
     return dic
 
 
@@ -584,39 +589,64 @@ def read_procs_file(dir='.', procs_files=None):
         Directory to read from.
     procs_files : list, optional
         List of filename(s) of procs parameter files in directory. None uses
-        standard files.
+        standard files. If filename(s) contains a full absolute path, dir is not used.
 
     Returns
     -------
     dic : dict
         Dictionary of Bruker parameters.
     """
-    if procs_files is None:
+
+    if not procs_files:
+
+        # Reading standard procs files
         procs_files = []
-        for f in ["procs", "proc2s", "proc3s", "proc4s"]:
-            if os.path.isfile(os.path.join(dir, f)):
-                procs_files.append(f)
+
         pdata_path = dir
+        for f in ["procs", "proc2s", "proc3s", "proc4s"]:
+            pf = os.path.join(pdata_path, f)
+            if os.path.isfile(pf):
+                procs_files.append(pf)
 
-    if procs_files == []:
-        if os.path.isdir(os.path.join(dir, 'pdata')):
-            pdata_folders = [folder for folder in
-                             os.walk(os.path.join(dir, 'pdata'))][0][1]
-            if '1' in pdata_folders:
-                pdata_path = os.path.join(dir, 'pdata', '1')
+        if not procs_files:
+            # procs not found in the given dir, try look adding pdata to the dir path
+
+            if os.path.isdir(os.path.join(dir, 'pdata')):
+                pdata_folders = [folder for folder in
+                                 os.walk(os.path.join(dir, 'pdata'))][0][1]
+                if '1' in pdata_folders:
+                    pdata_path = os.path.join(dir, 'pdata', '1')
+                else:
+                    pdata_path = os.path.join(dir, 'pdata', pdata_folders[0])
+
+            for f in procs_files:
+                pf = os.path.join(pdata_path, f)
+                if os.path.isfile(pf):
+                    procs_files.append(pf)
+
+    else:
+        # proc paths were explicitely given
+        # just check if they exists
+
+        for i, f in enumerate(procs_files):
+            pdata_path, f = os.path.split(f)
+            if not pdata_path:
+                pdata_path = dir
+
+            pf = os.path.join(pdata_path, f)
+            if not os.path.isfile(pf):
+                mesg = "The file `%s` could not be found "
+                warn(mesg % pf)
             else:
-                pdata_path = os.path.join(dir, 'pdata', pdata_folders[0])
-
-    for f in ["procs", "proc2s", "proc3s", "proc4s"]:
-            if os.path.isfile(os.path.join(pdata_path, f)):
-                procs_files.append(f)
+                procs_files[i] = pf
 
     # create an empty dictionary
     dic = dict()
 
     # read the acqus_files and add to the dictionary
     for f in procs_files:
-        dic[f] = read_jcamp(os.path.join(pdata_path, f))
+        pdata_path = os.path.basename(f)
+        dic[pdata_path] = read_jcamp(f)
     return dic
 
 
@@ -1192,6 +1222,11 @@ def read_pdata(dir=".", bin_files=None, procs_files=None, read_procs=True,
                 bin_files = ['3rrr']
         else:
             raise IOError("No Bruker binary file could be found in %s" % (dir))
+
+    for f in bin_files[1:]:
+        if not os.path.isfile(os.path.join(dir, f)):
+            bin_files = [bin_files[0]]
+            break
 
     if read_procs:
         # read the procs_files and add to the dictionary

--- a/nmrglue/fileio/tests/test_bruker.py
+++ b/nmrglue/fileio/tests/test_bruker.py
@@ -14,7 +14,8 @@ def test_read_pdata():
     """Reading processed bruker 1D data"""
 
     # read processed data
-    dic, data = ng.bruker.read_pdata(os.path.join(DATA_DIR, '1', 'pdata', '1'))
+    specdir = os.path.join(DATA_DIR, '1', 'pdata', '1')
+    dic, data = ng.bruker.read_pdata(specdir)
 
     # check that the data is correct
     assert np.all(data == [-36275840.0, -34775104.0])
@@ -26,13 +27,22 @@ def test_read_pdata():
     assert len(dic['procs'].keys()) == 131
     assert len(dic['acqus'].keys()) == 298
 
+    # specifying proc(s) files
+    # (fired this error in 0.8 version:
+    # UnboundLocalError: local variable 'pdata_path' referenced before
+    # assignment)
+
+    proc = os.path.join(specdir, 'procs')
+    dic, data = ng.bruker.read_pdata(specdir, procs_files = [proc])
+    assert len(dic['procs'].keys()) == 131
+
 
 def test_reorder_submatrix():
     """reordering submatrix back and forth"""
 
     # make a dummy matrix
     data = np.arange(16, dtype='float64').reshape(4, 4)
-    
+
     # correctly reordered matrix
     rdata = np.array([[ 0,  1,  4,  5],
                       [ 2,  3,  6,  7],
@@ -40,22 +50,22 @@ def test_reorder_submatrix():
                       [10, 11, 14, 15]], dtype='float64')
 
     # reorder from the submatrix form
-    r1data = ng.bruker.reorder_submatrix(data, shape=(4, 4), 
+    r1data = ng.bruker.reorder_submatrix(data, shape=(4, 4),
                                          submatrix_shape=(2, 2), reverse=False)
 
     # reorder to the submatrix form
-    r2data = ng.bruker.reorder_submatrix(r1data, shape=(4, 4), 
+    r2data = ng.bruker.reorder_submatrix(r1data, shape=(4, 4),
                                          submatrix_shape=(2, 2), reverse=True)
     # checks
     assert np.all(rdata == r1data)
     assert np.all(data == r2data)
-    
+
 
 def test_write_pdata():
     """ Writing a processed Bruker dataset """
 
     dic, data = ng.bruker.read_pdata(os.path.join(DATA_DIR, '1', 'pdata', '1'))
-    
+
     # write to a temperory file
     td = tempfile.mkdtemp('.')
     ng.bruker.write_pdata(td, dic, data, write_procs=True, pdata_folder=10)


### PR DESCRIPTION
Passing proc and procs files location using parameter `procs_files` in read_fid or read_pdata generate an error. 

` dic, data = ng.bruker.read_pdata(specdir, procs_files = ["somepath/procs"]) `

generate an error: 

```
        for f in ["procs", "proc2s", "proc3s", "proc4s"]:
>               if os.path.isfile(os.path.join(pdata_path, f)):
E               UnboundLocalError: local variable 'pdata_path' referenced before assignment

../bruker.py:611: UnboundLocalError
```
This pull request proposes to solve this problem by a modification of `read_procs_file` function in `bruker.py`.  It  adds also some changes in the `read_acqus_file` so that both functions can accept absolute path for acqu(s) and proc(s) files.
