### PR TITLE
Regression Bugfix

### DIFF
--- a/nmrglue/fileio/bruker.py
+++ b/nmrglue/fileio/bruker.py
@@ -619,7 +619,7 @@ def read_procs_file(dir='.', procs_files=None):
                 else:
                     pdata_path = os.path.join(dir, 'pdata', pdata_folders[0])
 
-            for f in procs_files:
+            for f in ["procs", "proc2s", "proc3s", "proc4s"]:
                 pf = os.path.join(pdata_path, f)
                 if os.path.isfile(pf):
                     procs_files.append(pf)


### PR DESCRIPTION
Fixed a regression bug introduced by #134. It prevented `procNs` files from being read in from standard directories when `read_procs=True` and `procs_files=None` is given to the `bruker.read` function.