### PR TITLE
Add test and docs for fileio.spinsolve

### DIFF
--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -19,6 +19,7 @@ fileio modules
     pipe
     rnmrtk
     simpson
+    spinsolve
     sparky
     table
     tecmag

--- a/doc/source/reference/spinsolve.rst
+++ b/doc/source/reference/spinsolve.rst
@@ -37,7 +37,7 @@ fine control over Spinsolve files may be interested in these functions.
 .. autosummary::
     :toctree: generated/
 
-    parse_spinsolve_acqu_line
+    parse_spinsolve_par_line
     get_udic_from_acqu_dict
     get_udic_from_jcamp_dict
 

--- a/doc/source/reference/spinsolve.rst
+++ b/doc/source/reference/spinsolve.rst
@@ -1,0 +1,43 @@
+nmrglue.spinsolve
+==============
+
+.. automodule:: nmrglue.fileio.spinsolve
+
+This modules is imported as nmrglue.spinsolve and can be called as such.
+
+User Information
+----------------
+
+User Functions
+^^^^^^^^^^^^^^
+
+These are functions which are targeted for users of nmrglue.
+
+.. autosummary::
+    :toctree: generated/
+
+    read
+    guess_udic
+
+
+
+Developer Information
+--------------------
+
+.. include:: ../../../nmrglue/fileio/spinsolve.py
+    :start-line: 14
+    :end-line: 37
+
+Developer Functions
+^^^^^^^^^^^^^^^^^^^
+
+These functions are typically not used directly by users.  Developers who want
+fine control over Spinsolve files may be interested in these functions.
+
+.. autosummary::
+    :toctree: generated/
+
+    parse_spinsolve_acqu_line
+    get_udic_from_acqu_dict
+    get_udic_from_jcamp_dict
+

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -43,20 +43,21 @@ containing a python dictionary with file and spectral parameters and a
 spectral data.  Currently the following file formats are supported by nmrglue
 with the associated module:
 
-=======  ======================== ==================
-Module   File Format              Reference 
-=======  ======================== ==================
-bruker   Bruker                   https://www.bruker.com/service/information-communication/user-manuals/nmr.html 
-pipe     NMRPipe                  https://www.ibbr.umd.edu/nmrpipe/index.html
-sparky   Sparky                   https://nmrfam.wisc.edu/nmrfam-sparky-distribution/
-varian   Varian/Agilent           
-rnmrtk   Rowland NMR Toolkit      https://rnmrtk.uchc.edu/rnmrtk/RNMRTK.html
-jcampdx  JCAMP-DX                 http://www.jcamp-dx.org/
-nmrml    NMR Markup Language      https://github.com/nmrML/nmrML
-simpson  Simpson                  https://inano.au.dk/about/research-centers/nmr/software/simpson/
-tecmag   Technology for Magnetic  https://www.tecmag.com/
-         Resonance
-=======  ======================== ==================
+=======    ======================== ==================
+Module     File Format              Reference
+=======    ======================== ==================
+bruker     Bruker                   https://www.bruker.com/service/information-communication/user-manuals/nmr.html
+pipe       NMRPipe                  https://www.ibbr.umd.edu/nmrpipe/index.html
+sparky     Sparky                   https://nmrfam.wisc.edu/nmrfam-sparky-distribution/
+varian     Varian/Agilent
+rnmrtk     Rowland NMR Toolkit      https://rnmrtk.uchc.edu/rnmrtk/RNMRTK.html
+jcampdx    JCAMP-DX                 http://www.jcamp-dx.org/
+nmrml      NMR Markup Language      https://github.com/nmrML/nmrML
+simpson    Simpson                  https://inano.au.dk/about/research-centers/nmr/software/simpson/
+spinsolve  Magritek or JCAMP-DX
+tecmag     Technology for Magnetic  https://www.tecmag.com/
+           Resonance
+=======    ======================== ==================
 
 Examining the data object in more detail:
 

--- a/nmrglue/fileio/jcampdx.py
+++ b/nmrglue/fileio/jcampdx.py
@@ -197,7 +197,7 @@ def _detect_format(dataline):
     # regexp to find & skip the first value of line, that never begins
     # with a pseudodigit in any format
     firstvalue_re = re.compile(
-        "(\s)*([+-]?\d+\.?\d*|[+-]?\.\d+)([eE][+-]?\d+)?(\s)*")
+        r"(\s)*([+-]?\d+\.?\d*|[+-]?\.\d+)([eE][+-]?\d+)?(\s)*")
 
     index = firstvalue_re.match(dataline).end()
     if index is None:
@@ -226,7 +226,7 @@ def _parse_affn_pac(datalines):
     # -if decimal separator is present, number can be given without leading
     #  zero (.1234) or decimals (123.)
     # -exponent (E/e) may be present
-    value_re = re.compile("(\s|,)*([+-]?\d+\.?\d*|[+-]?\.\d+)([eE][+-]?\d+)?")
+    value_re = re.compile(r"(\s|,)*([+-]?\d+\.?\d*|[+-]?\.\d+)([eE][+-]?\d+)?")
 
     data = []
     for dataline in datalines:
@@ -297,7 +297,7 @@ def _parse_pseudo(datalines):
 
     # regexp to find the first value of line, that never begins
     # with a pseudodigit (exponents are not allowed here)
-    firstvalue_re = re.compile("(\s)*([+-]?\d+\.?\d*|[+-]?\.\d+)")
+    firstvalue_re = re.compile(r"(\s)*([+-]?\d+\.?\d*|[+-]?\.\d+)")
 
     data = []
     currentmode = 0

--- a/nmrglue/fileio/spinsolve.py
+++ b/nmrglue/fileio/spinsolve.py
@@ -4,8 +4,8 @@ parameter (acqu.par/proc.par) files.
 """
 
 from warnings import warn
-from pathlib import Path
 
+import os
 import numpy as np
 
 from . import fileiobase
@@ -71,7 +71,7 @@ def read(dir='.', specfile=None, acqupar="acqu.par", procpar="proc.par"):
 
     Parameters
     ----------
-    dir : str, Path
+    dir : str
         Directory to read from
     specfile : str, optional
         Filename to import spectral data from. None uses standard filename from: 
@@ -94,7 +94,10 @@ def read(dir='.', specfile=None, acqupar="acqu.par", procpar="proc.par"):
 
     """
 
-    dir = Path(dir)
+    if os.path.isdir(dir) is not True:
+        raise IOError("directory %s does not exist" % (dir))
+
+
     if not dir.is_dir():
         raise IOError(f"Directory {dir} does not exist or is not a directory!")
 
@@ -134,7 +137,7 @@ def read(dir='.', specfile=None, acqupar="acqu.par", procpar="proc.par"):
     if specfile:
         inputfile = dir / specfile
         if not inputfile.is_file():
-            raise FileNotFoundError(f"File {inputfile} does not exist")
+            raise IOError(f"File {inputfile} does not exist")
     else:
         for priority in priority_list:
             inputfile = dir / priority

--- a/nmrglue/fileio/spinsolve.py
+++ b/nmrglue/fileio/spinsolve.py
@@ -179,7 +179,9 @@ def read(dir='.', specfile=None, acqupar="acqu.par", procpar="proc.par"):
 
 
 def get_udic_from_acqu_dict(param: dict):
-    """ Returns an udic from the parameters in acqu dictionary provided """
+    """
+    Returns an udic from the parameters in acqu dictionary provided.
+    """
     return_dict = dict()
 
     # Spectral Width (sw, in Hz)
@@ -198,7 +200,9 @@ def get_udic_from_acqu_dict(param: dict):
 
 
 def get_udic_from_jcamp_dict(param):
-    """ Returns an udic from the parameters in the JCAMP-DX dict provided """
+    """
+    Returns an udic from the parameters in the JCAMP-DX dict provided.
+    """
     return_dict = dict()
 
     # Observation Frequency (obs, in MHz)

--- a/nmrglue/fileio/spinsolve.py
+++ b/nmrglue/fileio/spinsolve.py
@@ -137,7 +137,7 @@ def read(dir='.', specfile=None, acqupar="acqu.par", procpar="proc.par"):
     else:
         for priority in priority_list:
             inputfile = os.path.join(dir, priority)
-            if not os.path.isfile(inputfile):
+            if os.path.isfile(inputfile):
                 break
     if inputfile is None:
         raise IOError("directory %s does not contain spectral data" % (dir))

--- a/nmrglue/fileio/spinsolve.py
+++ b/nmrglue/fileio/spinsolve.py
@@ -3,8 +3,8 @@ Functions for reading Magritek Spinsolve binary (dx/1d) files and
 parameter (acqu.par/proc.par) files.
 """
 
-import os
 from warnings import warn
+from pathlib import Path
 
 import numpy as np
 
@@ -13,16 +13,17 @@ from . import jcampdx
 
 __developer_info__ = """
 Spinsolve is the software used on the Magritek benchtop NMR devices. 
+
 A spectrum is saved in a folder with several files. The spectral data is
 stored in these files: 'data.1d' (FID), 'spectrum.1d' (Fourier transformed)
 and 'spectrum_processed.1d' (FT + processed by spinsolve)
 Optional spectral data (System->Prefs->Setup->Global data storage):
 'nmr_fid.dx' (FID stored in `JCAMP-DX standard <http://www.jcamp-dx.org/>`), 
-'spectrum.csv' and 'spectrum_processed.csv' (FT + processed by Spinsovle with ppm for each 
+'spectrum.csv' and 'spectrum_processed.csv' (FT + processed by Spinsolve with ppm for each 
 point and intensity delimited by ';')
 Other files:
 'acqu.par' - all parameters that are used for acquisition
-'Protocol.par' - text file used to reload data back into the Spinsolve software
+'protocol.par' - text file used to reload data back into the Spinsolve software
 'processing.script' - text file to transfer Spinsolve software protocol settings 
 into MNOVA
 
@@ -35,6 +36,27 @@ The Spinsolve Expert software has a slightly different output:
 - (new) .pt1 files - seem to be plot files specific for the expert software, cannot
 be read by NMRglue
 """
+
+
+def parse_spinsolve_acqu_line(line):
+    """
+    Parse lines in acqu.par and return a tuple (paramter name, parameter value)
+    """
+    line = line.strip()  # Drop newline
+    name, value = line.split("=")  # Split at equal sign
+
+    # remove spaces
+    name = name.strip()
+    value = value.strip()
+
+    # Detect value type
+    if value[0] == value[-1] == '"':  # String
+        return name, str(value[1:-1])  # Drop quote marks
+    if "." in value:  # Float
+        return name, float(value)
+    else:
+        return name, int(value)
+
 
 def read(dir='.', specfile=None, acqupar="acqu.par", procpar="proc.par"):
     """
@@ -49,7 +71,7 @@ def read(dir='.', specfile=None, acqupar="acqu.par", procpar="proc.par"):
 
     Parameters
     ----------
-    dir : str
+    dir : str, Path
         Directory to read from
     specfile : str, optional
         Filename to import spectral data from. None uses standard filename from: 
@@ -71,27 +93,34 @@ def read(dir='.', specfile=None, acqupar="acqu.par", procpar="proc.par"):
         Array of NMR data
 
     """
-    
-    if os.path.isdir(dir) is not True:
-        raise IOError("directory %s does not exist" % (dir))
+
+    dir = Path(dir)
+    if not dir.is_dir():
+        raise IOError(f"Directory {dir} does not exist or is not a directory!")
 
     # Create empty dic
-    dic = {"spectrum": {}, "acqu": {}, "proc":{}, "dx":{}} 
-    
+    dic = {
+        "spectrum": {},
+        "acqu": {},
+        "proc": {},
+        "dx": {}
+    }
+
     # Read in acqu.par and write to dic
-    acqupar = os.path.join(dir, acqupar)
-    if os.path.isfile(acqupar):
-        with open(acqupar, "r") as f:
+    acqupar = dir / acqupar
+    if acqupar.is_file():
+        with acqupar.open() as f:
             info = f.readlines()
         for line in info:
-            line = line.replace("\n", "")
-            k, v = line.split("=")
-            dic["acqu"][k.strip()] = v.strip()
+            par_name, par_value = parse_spinsolve_acqu_line(line)
+
+            if par_name is not None:
+                dic["acqu"][par_name] = par_value
 
     # Read in proc.par and write to dic
-    procpar = os.path.join(dir,procpar)
-    if os.path.isfile(procpar):
-        with open(procpar, "r") as f:
+    procpar = dir / procpar
+    if procpar.is_file():
+        with acqupar.open() as f:
             info = f.readlines()
         for line in info:
             line = line.replace("\n", "")
@@ -100,57 +129,113 @@ def read(dir='.', specfile=None, acqupar="acqu.par", procpar="proc.par"):
 
     # Define which spectrumfile to take, using 'specfile' when defined, otherwise 
     # the files in 'priority_list' are tried, in that particular order
-    priority_list = ["nmr_fid.dx", "data.1d", "fid.1d", "spectrum.1d", "spectrum_processed.1d", None]
-    if specfile: 
-        inputfile = os.path.join(dir, specfile)
-        if not os.path.isfile(inputfile):
-            raise IOError("File %s does not exist" % (inputfile))
+    priority_list = ["nmr_fid.dx", "data.1d", "fid.1d", "spectrum.1d", "spectrum_processed.1d"]
+    inputfile = None
+    if specfile:
+        inputfile = dir / specfile
+        if not inputfile.is_file():
+            raise FileNotFoundError(f"File {inputfile} does not exist")
     else:
         for priority in priority_list:
-            if priority == None:
-                raise IOError("directory %s does not contain spectral data" % (dir))
-            inputfile = os.path.join(dir, priority)
-            if os.path.isfile(inputfile):
+            inputfile = dir / priority
+            if inputfile.is_file():
                 break
-
+    if inputfile is None:
+        raise IOError(f"Directory {dir} does not contain spectral data")
 
     # Detect which file we are dealing with from the extension and read in the spectral data
+
     # Reading .dx file using existing nmrglue.fileio.jcampdx module
-    if inputfile.split('.')[-1] == "dx":
-        dic["dx"], raw_data = jcampdx.read(inputfile)
-        data = np.empty((int(dic["dx"]["$TD"][0]), ), dtype='complex128')
+    if inputfile.suffix == ".dx":
+        dic["dx"], raw_data = jcampdx.read(str(inputfile.absolute()))
         data = raw_data[0][:] + 1j * raw_data[1][:]
-        
+
     # Reading .1d files
-    elif inputfile.split('.')[-1] == "1d":
-        with open(inputfile, "rb") as f:
-            raw_data = f.read()  
-        
+    elif inputfile.suffix == ".1d":
+        with inputfile.open("rb") as f:
+            raw_data = f.read()
+
         # Write out parameters from the first 32 bytes into dic["spectrum"]
         keys = ["owner", "format", "version", "dataType", "xDim", "yDim", "zDim", "qDim"]
         for i, k in enumerate(keys):
             start = i * 4
             end = start + 4
-            value = int.from_bytes( raw_data[start:end], "little")
+            value = int.from_bytes(raw_data[start:end], "little")
             dic["spectrum"][k] = value
-        data = np.frombuffer(raw_data[end:], "<f")
+        data = np.frombuffer(raw_data[32:], "<f")
 
         # The first 1/3 of the file is xaxis data (s or ppm)
         split = data.shape[-1] // 3
-        xscale = data[0 : split]
+        xscale = data[0: split]
         dic["spectrum"]["xaxis"] = xscale
 
         # The rest is real and imaginary data points interleaved
-        data = data[split : : 2] + 1j * data[split + 1 : : 2]
+        data = data[split:: 2] + 1j * data[split + 1:: 2]
 
     else:
-        raise IOError("File %s cannot be interpreted, use .dx or .1d instead" % (inputfile))
+        raise IOError(f"File {inputfile} cannot be interpreted, use .dx or .1d instead")
 
-    return dic,data
+    return dic, data
 
 
+def get_udic_from_acqu_dict(param: dict):
+    """ Returns an udic from the parameters in acqu dictionary provided """
+    return_dict = dict()
 
-def guess_udic(dic,data):
+    # Spectral Width (sw, in Hz)
+    return_dict['sw'] = float(param.get('bandwidth')) * 1000
+
+    # Observation Frequency (obs, in MHz)
+    return_dict['obs'] = float(param.get('b1Freq'))
+
+    # Carrier frequency (car, in Hz)
+    return_dict['car'] = float(param.get('lowestFrequency')) + (return_dict['sw'] / 2)
+
+    # Label (str describing the axis name)
+    return_dict['label'] = param['rxChannel']
+
+    return return_dict
+
+
+def get_udic_from_jcamp_dict(param):
+    """ Returns an udic from the parameters in the JCAMP-DX dict provided """
+    return_dict = dict()
+
+    # Observation Frequency (obs, in MHz)
+    try:
+        return_dict['obs'] = float(param['$BF1'][0])
+    except KeyError:
+        warn("Cannot set observation frequency - set manually using: 'udic[0]['obs'] = x' "
+             "where x is magnetic field in MHz")
+
+    # Spectral Width (sw, in Hz)
+    try:
+        return_dict['sw'] = float(param['$SW'][0]) * return_dict['obs']
+    except KeyError:
+        warn("Cannot set spectral width - set manually using: 'udic[0]['sw'] = x' "
+             "where x is the spectral width in Hz")
+
+    # Carrier frequency (car, in Hz)
+    try:
+        return_dict['car'] = -float(param['$REFERENCEPOINT'][0]) + (return_dict['sw'] / 2)
+    except KeyError:
+        pass
+    try:
+        return_dict['car'] = (return_dict['obs'] - float(param['$SF'][0])) * 1e6
+    except KeyError:
+        warn("Cannot set carrier - try: 'udic[0]['car'] = x * udic[0]['obs']' "
+             "where x is the center of the spectrum in ppm")
+
+    # Label (str describing the axis name)
+    try:
+        return_dict['label'] = param[".OBSERVENUCLEUS"][0].replace("^", "")
+    except KeyError:
+        warn("Cannot set observed nucleus label")
+
+    return return_dict
+
+
+def guess_udic(dic, data):
     """
     Guess parameters of universal dictionary from dic, data pair.
 
@@ -170,64 +255,21 @@ def guess_udic(dic,data):
     # Create an empty universal dictionary
     udic = fileiobase.create_blank_udic(1)
 
-    # Update defalt parameters, first acqu.par parameters in dic are tried, then JCAMP-DX header parameters
-    # size
+    # Size can be calculated from data len
     if data is not None:
         udic[0]["size"] = len(data)
     else:
         warn('No data, cannot set udic size')
-    
-    # sw
-    try:
-        udic[0]['sw'] = float(dic['acqu']['bandwidth']) * 1000
-    except KeyError:
-        try:
-            udic[0]['sw'] = float(dic['dx']['$SW'][0]) * float(dic['dx']['$BF1'][0])
-        except KeyError:
-            try:
-                if dic["spectrum"]["freqdata"]:
-                    udic[0]['sw'] = dic["spectrum"]["xaxis"][-1] - dic["spectrum"]["xaxis"][0]
-                elif data is not None:
-                    udic[0]['sw'] = len(data) / dic["spectrum"]["xaxis"][-1]
-                else:
-                    warn("Cannot set spectral width - set manually using: 'udic[0]['sw'] = x' where x is the spectral width in Hz")
-            except KeyError:
-                warn("Cannot set spectral width - set manually using: 'udic[0]['sw'] = x' where x is the spectral width in Hz")
-    
-    # obs
-    try:
-        udic[0]['obs'] = float(dic['acqu']['b1Freq'])
-    except KeyError:
-        try:
-            udic[0]['obs'] = float(dic['dx']['$BF1'][0])
-        except KeyError:
-            warn("Cannot set observe frequency - set manually using: 'udic[0]['obs'] = x' where x is magnetic field in MHz")
-    
-    # car
-    try:
-        udic[0]['car'] = float(dic['acqu']['lowestFrequency']) + (float(dic['acqu']['bandwidth']) * 1000 / 2)
-    except KeyError:
-        try:
-            udic[0]['car'] = (float(dic['dx']['$REFERENCEPOINT'][0]) * -1 ) + (float(dic['dx']['$SW'][0]) * udic[0]['obs'] / 2)
-        except KeyError:
-            try:
-                udic[0]['car'] = (float(dic['dx']['$BF1'][0]) - float(dic['dx']['$SF'][0])) * 1000000
-            except KeyError:
-                warn("Cannot set carrier - try: 'udic[0]['car'] = x * udic[0]['obs']' where x is the center of the spectrum in ppm")
 
-    # label
-    try:
-        udic[0]['label'] = dic['acqu']['rxChannel']
-    except KeyError:
-        try:
-            label_value = dic['dx'][".OBSERVENUCLEUS"][0].replace("^", "")
-            udic[0]["label"] = label_value
-        except KeyError:
-            warn("Cannot set observed nucleus label")
-    
-    #keys left to default
-        # udic[0]['complex']
-        # udic[0]['encoding']
-        # udic[0]['time'] = True
-        # udic[0]['freq'] = False
+    # For the other parameters, first try to use info from acqu.par (dic['acqu']), then JCAMP-DX header parameters
+    if dic["acqu"]:
+        udic[0].update(get_udic_from_acqu_dict(dic["acqu"]))
+    else:
+        udic[0].update(get_udic_from_jcamp_dict(dic["dx"]))
+
+    # keys left to default
+    # udic[0]['complex']
+    # udic[0]['encoding']
+    # udic[0]['time'] = True
+    # udic[0]['freq'] = False
     return udic

--- a/nmrglue/fileio/spinsolve.py
+++ b/nmrglue/fileio/spinsolve.py
@@ -150,7 +150,7 @@ def read(dir='.', specfile=None, acqupar="acqu.par", procpar="proc.par"):
         data = raw_data[0][:] + 1j * raw_data[1][:]
 
     # Reading .1d files
-    elif inputfile.split('.')[-1] == ".1d":
+    elif inputfile.split('.')[-1] == "1d":
         with open(inputfile, "rb") as f:
             raw_data = f.read()
 

--- a/nmrglue/fileio/spinsolve.py
+++ b/nmrglue/fileio/spinsolve.py
@@ -177,6 +177,30 @@ def read(dir='.', specfile=None, acqupar="acqu.par", procpar="proc.par"):
     return dic, data
 
 
+def make_uc(dic, data):
+    """
+    Create a unit conversion object (only 1D).
+
+    Essentially identical to fileiobase.uc_from_udic() but uses data.size for size
+    so that it still works after zero filling
+
+    Parameters
+    ----------
+    dic : dict
+        Dictionary of Spinsolve parameters.
+    data : ndarray
+        Array of NMR data.
+
+    Returns
+    -------
+    uc : unit conversion object
+        Unit conversion object for given dimension.
+
+    """
+    udic = guess_udic(dic, data)
+    return fileiobase.unit_conversion(data.size, udic[0]['complex'], udic[0]['sw'], udic[0]['obs'], udic[0]['car'])
+
+
 def get_udic_from_acqu_dict(param: dict):
     """
     Returns an udic from the parameters in acqu dictionary provided.

--- a/nmrglue/fileio/spinsolve.py
+++ b/nmrglue/fileio/spinsolve.py
@@ -1,5 +1,5 @@
 """
-Functions for reading Magritek Spinsolve binary (dx/1d) files and 
+Functions for reading Magritek Spinsolve binary (dx/1d) files and
 parameter (acqu.par/proc.par) files.
 """
 
@@ -38,7 +38,7 @@ be read by NMRglue
 """
 
 
-def parse_spinsolve_acqu_line(line):
+def parse_spinsolve_par_line(line):
     """
     Parse lines in acqu.par and return a tuple (paramter name, parameter value)
     """
@@ -61,12 +61,12 @@ def parse_spinsolve_acqu_line(line):
 def read(dir='.', specfile=None, acqupar="acqu.par", procpar="proc.par"):
     """
     Reads spinsolve files from a directory
-    When no spectrum filename is given (specfile), the following list is tried, in 
+    When no spectrum filename is given (specfile), the following list is tried, in
     that specific order
     ["nmr_fid.dx", "data.1d", "fid.1d", "spectrum.1d", "spectrum_processed.1d"]
     To use the resolution enhanced spectrum use the './Enhanced' folder as input.
-    Note that spectrum.1d and spectrum_processed.1d contain only data in the 
-    frequency domain, so no Fourier transformation is needed. Also, use 
+    Note that spectrum.1d and spectrum_processed.1d contain only data in the
+    frequency domain, so no Fourier transformation is needed. Also, use
     dic["spectrum"]["xaxis"] to plot the x-axis
 
     Parameters
@@ -74,7 +74,7 @@ def read(dir='.', specfile=None, acqupar="acqu.par", procpar="proc.par"):
     dir : str
         Directory to read from
     specfile : str, optional
-        Filename to import spectral data from. None uses standard filename from: 
+        Filename to import spectral data from. None uses standard filename from:
         ["nmr_fid.dx", "data.1d", "fid.1d", "spectrum.1d", "spectrum_processed.1d"]
     acqupar : str, optional
         Filename for acquisition parameters. None uses standard name.
@@ -111,7 +111,7 @@ def read(dir='.', specfile=None, acqupar="acqu.par", procpar="proc.par"):
         with open(acqupar, "r") as f:
             info = f.readlines()
         for line in info:
-            par_name, par_value = parse_spinsolve_acqu_line(line)
+            par_name, par_value = parse_spinsolve_par_line(line)
 
             if par_name is not None:
                 dic["acqu"][par_name] = par_value
@@ -126,7 +126,7 @@ def read(dir='.', specfile=None, acqupar="acqu.par", procpar="proc.par"):
             k, v = line.split("=")
             dic["proc"][k.strip()] = v.strip()
 
-    # Define which spectrumfile to take, using 'specfile' when defined, otherwise 
+    # Define which spectrumfile to take, using 'specfile' when defined, otherwise
     # the files in 'priority_list' are tried, in that particular order
     priority_list = ["nmr_fid.dx", "data.1d", "fid.1d", "spectrum.1d", "spectrum_processed.1d"]
     inputfile = None
@@ -272,7 +272,7 @@ def guess_udic(dic, data):
         Dictionary of JCAMP-DX, acqu, proc and spectrum parameters.
     data : ndarray
         Array of NMR data.
-    
+
     Returns
     -------
     udic : dict

--- a/tests/test_spinsolve.py
+++ b/tests/test_spinsolve.py
@@ -1,0 +1,57 @@
+""" Tests for the fileio.spinsolve submodule """
+
+
+import nmrglue as ng
+from pathlib import Path
+
+from setup import DATA_DIR
+
+
+def test_acqu():
+    """ read nmr_fid.dx """
+    dic, data = ng.spinsolve.read(Path(DATA_DIR) / "spinsolve" / "ethanol", "nmr_fid.dx")
+    assert dic["acqu"]["Sample"] == "EtOH"
+    assert dic["acqu"]["Solvent"] == "None"
+
+
+def test_jcamp_dx():
+    """ read nmr_fid.dx """
+    dic, data = ng.spinsolve.read(Path(DATA_DIR) / "spinsolve" / "ethanol", "nmr_fid.dx")
+    assert data.size == 32768
+    assert data.shape == (32768,)
+    assert "Magritek Spinsolve" in dic["dx"]["_comments"][0]
+
+
+def test_data1d():
+    """ read nmr_fid.dx """
+    dic, data = ng.spinsolve.read(Path(DATA_DIR) / "spinsolve" / "ethanol", "data.1d")
+    assert dic["spectrum"]["xDim"] == 32768
+    assert len(dic["spectrum"]["xaxis"]) == 32768
+    assert data.size == 32768
+    assert data.shape == (32768,)
+
+
+def test_guess_acqu():
+    """ guess_udic based on acqu dictionary """
+    dic, data = ng.spinsolve.read(Path(DATA_DIR) / "spinsolve" / "ethanol", "nmr_fid.dx")
+    udic = ng.spinsolve.guess_udic(dic, data)
+    assert udic[0]["sw"] == 5000
+    assert 43.49 < udic[0]["obs"] < 43.50
+    assert 206 < udic[0]["car"] < 207
+    assert udic[0]["size"] == 32768
+    assert udic[0]["label"] == "1H"
+
+
+def test_guess_jcamp_dx():
+    """ guess_udic based on dx dictionary """
+    dic, data = ng.spinsolve.read(Path(DATA_DIR) / "spinsolve" / "ethanol", "nmr_fid.dx")
+
+    # Drop acqu dict that would be used as default
+    dic["acqu"] = {}
+
+    udic = ng.spinsolve.guess_udic(dic, data)
+    assert 4999 < udic[0]["sw"] < 5001
+    assert 43.49 < udic[0]["obs"] < 43.50
+    assert 206 < udic[0]["car"] < 207
+    assert udic[0]["size"] == 32768
+    assert udic[0]["label"] == "1H"


### PR DESCRIPTION
Few improvements to the spinsolve import module

* minor change to acqu.par parsing, e.g. now `["Sample"] == "EtOH"` before it was  `["Sample"] == "\"EtOH\""` (with additional quote marks)
* Added info to docs
* Tests added (the spectrum referenced in the test has not been added as the `/data/` folder is in .gitignore, where can I put it? Also, how to run the tests for the other modules (e.g. bruker)?