### PR TITLE
Read from binary stream

### DIFF
--- a/doc/source/devel/index.rst
+++ b/doc/source/devel/index.rst
@@ -119,7 +119,7 @@ The directory layout of the nmrglue project is as follows.
   many real world NMR problems.
 
 
-Two additional directories can be created to aid in developements.  These are
+Two additional directories can be created to aid in developments.  These are
 not required but will be ignored by git using the default ``.gitignore`` file 
 
 * ``data`` : Suggested location to hold the :ref:`test data <test_data>`.
@@ -140,20 +140,20 @@ preparing patches.
   `pylint <http://www.logilab.org/857>`_ to check your Python code against 
   these conventions.
 
-* Documentation : All public functions and classes should have docstring which
+* Documentation : All public functions and classes should have a docstring which
   follows the `NumPy/SciPy documentation standard 
   <https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt>`_.  
-  Prive functions and classes may have shorter dostrings.  The nmrglue 
+  Private functions and classes may have shorter dostrings.  The nmrglue 
   documentation is build using `Sphinx <http://sphinx.pocoo.org/>`__.  Sphinx 
   translates `reST <http://docutils.sourceforge.net/rst.html>`_ formatted 
-  documents (including docstring) into html.  When adding new function,
-  classes or parameter to nmrglue please update the docstring and make any
+  documents (including docstring) into html.  When adding new functions,
+  classes or parameters to nmrglue please update the docstring and make any
   necessary changes to the Sphinx files in the doc directory.
   
 * :ref:`testing` : Tests are available for verifying the functionality of
   nmrglue, please include a tests when adding new functionality to the package.
 
-* Examples : Numerous example showing real world use of nmrglue are provided in
+* Examples : Numerous examples showing real world use of nmrglue are provided in
   the ``examples`` directory.  Contributions of additional example are welcome
   and appreciated.  
 
@@ -195,20 +195,20 @@ After ensuring that all required packages are installed and ``setup.py``
 correctly points to the location of the test data directory, the unit tests can
 be run using the following::
 
-    nosetest
+    nosetests
 
 Unit tests for a specific module can be run using::
 
-    nosetest tests/test_pipe.py
+    nosetests tests/test_pipe.py
 
-Additional information on the `usage of the nosetest command
+Additional information on the `usage of the nosetests command
 <https://nose.readthedocs.org/en/latest/usage.html>`_ is available.
 
 
 Reporting Bugs
 --------------
 
-The preferred location for submitting feature requests and bugs reported 
+The preferred location for submitting feature requests and reporting bugs
 is the `github issue tracker <https://github.com/jjhelmus/nmrglue/issues>`_.
 Reports are also welcomed on the 
 `nmrglue mailing list <http://groups.google.com/group/nmrglue-discuss>`_ or by

--- a/nmrglue/fileio/pipe.py
+++ b/nmrglue/fileio/pipe.py
@@ -7,7 +7,6 @@ from __future__ import print_function, division
 __developer_info__ = """
 NMRPipe file structure is described in the NMRPipe man pages and fdatap.h
 """
-import io
 import struct
 import datetime
 import os

--- a/nmrglue/fileio/pipe.py
+++ b/nmrglue/fileio/pipe.py
@@ -1543,7 +1543,6 @@ def fdata2dic(fdata):
     def _unpack_str(fmt, d):
         return struct.unpack(fmt, d)[0].decode().strip('\x00')
 
-
     # Populate the dictionary with FDATA which contains strings
     dic["FDF2LABEL"] = _unpack_str('8s', fdata[16:18])
     dic["FDF1LABEL"] = _unpack_str('8s', fdata[18:20])
@@ -1601,7 +1600,7 @@ def dic2fdata(dic):
 #################################
 
 
-def get_fdata(filename: Union[str, bytes]):
+def get_fdata(filename: Union[str, bytes]) -> np.array:
     """
     Get an array of length 512-bytes holding NMRPipe header.
     """
@@ -1615,7 +1614,7 @@ def get_fdata(filename: Union[str, bytes]):
     return fdata
 
 
-def get_data(filename: Union[str, bytes]):
+def get_data(filename: Union[str, bytes]) -> np.array:
     """
     Get array of data
     """
@@ -1629,7 +1628,7 @@ def get_data(filename: Union[str, bytes]):
     return data[512:]
 
 
-def get_fdata_data(filename: Union[str, bytes]):
+def get_fdata_data(filename: Union[str, bytes]) -> Tuple[np.array, np.array]:
     """
     Get fdata and data array, return (fdata, data)
     """

--- a/nmrglue/fileio/pipe.py
+++ b/nmrglue/fileio/pipe.py
@@ -7,10 +7,12 @@ from __future__ import print_function, division
 __developer_info__ = """
 NMRPipe file structure is described in the NMRPipe man pages and fdatap.h
 """
-
+import io
 import struct
 import datetime
 import os
+from typing import Tuple
+
 try:
     from StringIO import StringIO
 except ImportError:
@@ -587,6 +589,54 @@ def read_lowmem(filename):
 
     raise ValueError('unknown dimentionality: %s' % order)
 
+def read_bytes(data_bytes: bytes):
+    """
+    Read a NMRPipe file.
+
+    For standard multi-file 3D/4D NMRPipe data sets, filename should be a
+    filemask (for example "/ft/test%03d.ft3") with a "%" formatter.  If only
+    one file of a 3D/4D data set is provided only that 2D slice of the data is
+    read (for example "/ft/test001.ft3" results in a 2D data set being read).
+
+    NMRPipe data streams stored as files (one file 3D/4D data sets made using
+    xyz2pipe) can be read by providing the file name of the stream.  The entire
+    data set is read into memory.
+
+    Parameters
+    ----------
+    filename : str
+        Filename or filemask of NMRPipe file(s) to read.
+
+    Returns
+    --------
+    dic : dict
+        Dictionary of NMRPipe parameters.
+    data : ndarray
+        Array of NMR data.
+
+    See Also
+    --------
+    read_lowmem : NMRPipe file reading with minimal memory usage.
+    write : Write a NMRPipe data to file(s).
+
+    """
+    fdata = get_fdata_bytes(data_bytes)
+    dic = fdata2dic(fdata)
+    order = dic["FDDIMCOUNT"]
+
+    if order == 1:
+        return read_1D_bytes(data_bytes)
+    if order == 2:
+        return read_2D_bytes(data_bytes)
+    if dic["FDPIPEFLAG"] != 0:  # open streams
+        return read_stream(data_bytes)
+    #if filemask is None:     # if no filemask open as 2D
+    #    return read_2D(data_bytes)
+    if order == 3:
+        return read_3D(data_bytes)
+    if order == 4:
+        return read_4D(data_bytes)
+    raise ValueError('unknown dimensionality: %s' % order)
 
 # dimension specific reading
 def read_1D(filename):
@@ -607,6 +657,23 @@ def read_1D(filename):
     return (dic, data)
 
 
+def read_1D_bytes(bytes):
+    """
+    Read a 1D NMRPipe file.
+
+    See :py:func:`read` for documentation.
+
+    """
+    fdata, data = get_fdata_data_bytes(bytes)   # get the fdata and data arrays
+    dic = fdata2dic(fdata)  # convert the fdata block to a python dictionary
+    data = reshape_data(data, find_shape(dic))    # reshape data
+
+    # unappend imaginary data if needed
+    if dic["FDF2QUADFLAG"] != 1:
+        data = unappend_data(data)
+
+    return (dic, data)
+
 def read_2D(filename):
     """
     Read a 2D NMRPipe file or NMRPipe data stream.
@@ -615,6 +682,26 @@ def read_2D(filename):
 
     """
     fdata, data = get_fdata_data(filename)   # get the fdata and data arrays
+    dic = fdata2dic(fdata)  # convert the fdata block to a python dictionary
+    data = reshape_data(data, find_shape(dic))    # reshape data
+
+    # unappend imaginary data if needed
+    if dic["FDTRANSPOSED"] == 1 and dic["FDF1QUADFLAG"] != 1:
+        data = unappend_data(data)
+    elif dic["FDTRANSPOSED"] == 0 and dic["FDF2QUADFLAG"] != 1:
+        data = unappend_data(data)
+
+    return (dic, data)
+
+
+def read_2D_bytes(data_bytes):
+    """
+    Read a 2D NMRPipe file or NMRPipe data stream.
+
+    See :py:func:`read` for documentation.
+
+    """
+    fdata, data = get_fdata_data_bytes(data_bytes)   # get the fdata and data arrays
     dic = fdata2dic(fdata)  # convert the fdata block to a python dictionary
     data = reshape_data(data, find_shape(dic))    # reshape data
 
@@ -1531,6 +1618,8 @@ def fdata2dic(fdata):
 
     def _unpack_str(fmt, d):
         return struct.unpack(fmt, d)[0].decode().strip('\x00')
+        #return struct.unpack(fmt, d)[0].decode('utf-8', 'replace')
+        #return struct.unpack(fmt, d)[0]
 
     # Populate the dictionary with FDATA which contains strings
     dic["FDF2LABEL"] = _unpack_str('8s', fdata[16:18])
@@ -1617,6 +1706,41 @@ def get_fdata_data(filename):
     if data[2] - 2.345 > 1e-6:  # check for byteswap
         data = data.byteswap()
     return data[:512], data[512:]
+
+
+def get_fdata_bytes(data: bytes) -> np.array:
+    """
+    Get an array of length 512-bytes holding NMRPipe header.
+    """
+    data  = struct.unpack("f" * (len(data) // 4), data)
+    data = np.asarray(data, dtype="float32")
+    fdata = data[:512]
+    if fdata[2] - 2.345 > 1e-6:    # fdata[2] should be 2.345
+        fdata = fdata.byteswap()
+    return fdata
+
+
+def get_data_bytes(data: bytes) -> np.array:
+    """
+    Get array of data from binary stream
+    """
+    data  = struct.unpack("f" * (len(data) // 4), data)
+    data = np.asarray(data, dtype="float32")
+    if data[2] - 2.345 > 1e-6:  # check for byteswap
+        data = data.byteswap()
+    return data[512:]
+
+
+def get_fdata_data_bytes(data: bytes) -> Tuple[np.array, np.array]:
+    """
+    Get fdata and data array from binary stream, return (fdata, data)
+    """
+    data  = struct.unpack("f" * (len(data) // 4), data)
+    data = np.asarray(data, dtype="float32")
+    if data[2] - 2.345 > 1e-6:  # check for byteswap
+        data = data.byteswap()
+    return data[:512], data[512:]
+
 
 ##############################################
 # low memory numpy.ndarray emulating objects #

--- a/nmrglue/fileio/pipe.py
+++ b/nmrglue/fileio/pipe.py
@@ -483,7 +483,7 @@ def dic2datetime(dic):
 ################
 
 
-def read(filename: Union[str, bytes, io.BytesIO]) -> Tuple[dict, np.array]:
+def read(filename):
     """
     Read a NMRPipe file.
 
@@ -1600,7 +1600,7 @@ def dic2fdata(dic):
 #################################
 
 
-def get_fdata(filename: Union[str, bytes]) -> np.array:
+def get_fdata(filename):
     """
     Get an array of length 512-bytes holding NMRPipe header.
     """
@@ -1614,7 +1614,7 @@ def get_fdata(filename: Union[str, bytes]) -> np.array:
     return fdata
 
 
-def get_data(filename: Union[str, bytes]) -> np.array:
+def get_data(filename):
     """
     Get array of data
     """
@@ -1628,7 +1628,7 @@ def get_data(filename: Union[str, bytes]) -> np.array:
     return data[512:]
 
 
-def get_fdata_data(filename: Union[str, bytes]) -> Tuple[np.array, np.array]:
+def get_fdata_data(filename):
     """
     Get fdata and data array, return (fdata, data)
     """

--- a/nmrglue/fileio/pipe.py
+++ b/nmrglue/fileio/pipe.py
@@ -11,7 +11,6 @@ import io
 import struct
 import datetime
 import os
-from typing import Tuple, Union
 
 try:
     from StringIO import StringIO

--- a/nmrglue/fileio/pipe.py
+++ b/nmrglue/fileio/pipe.py
@@ -1607,12 +1607,13 @@ def get_fdata(filename: Union[str, bytes]):
     Get an array of length 512-bytes holding NMRPipe header.
     """
     if type(filename) is bytes:
-        return get_fdata_bytes(filename)
+        fdata = np.frombuffer(filename, dtype=np.float32, count=512)
     else:
         fdata = np.fromfile(filename, 'float32', 512)
-        if fdata[2] - 2.345 > 1e-6:    # fdata[2] should be 2.345
-            fdata = fdata.byteswap()
-        return fdata
+
+    if fdata[2] - 2.345 > 1e-6:    # fdata[2] should be 2.345
+        fdata = fdata.byteswap()
+    return fdata
 
 
 def get_data(filename: Union[str, bytes]):
@@ -1620,12 +1621,13 @@ def get_data(filename: Union[str, bytes]):
     Get array of data
     """
     if type(filename) is bytes:
-        return get_data_bytes(filename)
+        data = np.frombuffer(filename, dtype=np.float32)
     else:
         data = np.fromfile(filename, 'float32')
-        if data[2] - 2.345 > 1e-6:  # check for byteswap
-            data = data.byteswap()
-        return data[512:]
+    
+    if data[2] - 2.345 > 1e-6:  # check for byteswap
+        data = data.byteswap()
+    return data[512:]
 
 
 def get_fdata_data(filename: Union[str, bytes]):
@@ -1633,39 +1635,10 @@ def get_fdata_data(filename: Union[str, bytes]):
     Get fdata and data array, return (fdata, data)
     """
     if type(filename) is bytes:
-        return get_fdata_data_bytes(filename)
+        data = np.frombuffer(filename, dtype=np.float32)
     else:
         data = np.fromfile(filename, 'float32')
-        if data[2] - 2.345 > 1e-6:  # check for byteswap
-            data = data.byteswap()
-        return data[:512], data[512:]
 
-
-def get_fdata_bytes(data: bytes) -> np.array:
-    """
-    Get an array of length 512-bytes holding NMRPipe header.
-    """
-    fdata = np.frombuffer(data, dtype=np.float32, count=512)
-    if fdata[2] - 2.345 > 1e-6:    # fdata[2] should be 2.345
-        fdata = fdata.byteswap()
-    return fdata
-
-
-def get_data_bytes(data: bytes) -> np.array:
-    """
-    Get array of data from binary stream
-    """
-    data = np.frombuffer(data, dtype=np.float32)
-    if data[2] - 2.345 > 1e-6:  # check for byteswap
-        data = data.byteswap()
-    return data[512:]
-
-
-def get_fdata_data_bytes(data: bytes) -> Tuple[np.array, np.array]:
-    """
-    Get fdata and data array from binary stream, return (fdata, data)
-    """
-    data = np.frombuffer(data, dtype=np.float32)
     if data[2] - 2.345 > 1e-6:  # check for byteswap
         data = data.byteswap()
     return data[:512], data[512:]

--- a/nmrglue/fileio/pipe.py
+++ b/nmrglue/fileio/pipe.py
@@ -488,19 +488,22 @@ def read(filename: Union[str, bytes, io.BytesIO]) -> Tuple[dict, np.array]:
     Read a NMRPipe file.
 
     For standard multi-file 3D/4D NMRPipe data sets, filename should be a
-    filemask (for example "/ft/test%03d.ft3") with a "%" formatter.  If only
+    filemask (for example "/ft/test%03d.ft3") with a "%" formatter. If only
     one file of a 3D/4D data set is provided only that 2D slice of the data is
     read (for example "/ft/test001.ft3" results in a 2D data set being read).
 
     NMRPipe data streams stored as files (one file 3D/4D data sets made using
-    xyz2pipe) can be read by providing the file name of the stream.  The entire
+    xyz2pipe) can be read by providing the file name of the stream. The entire
     data set is read into memory.
+
+    An in memory binary stream (io.BytesIO) or bytes buffer containing an NMRPipe
+    dataset can also be read.
 
     Parameters
     ----------
     filename : str | bytes | io.BytesIO
         Filename or filemask of NMRPipe file(s) to read. Binary io.BytesIO stream 
-        (e.g. from open(filename, "rb")) or bytes buffer can also be provided
+        (e.g. open(filename, "rb")) or bytes buffer can also be provided
 
     Returns
     --------

--- a/tests/test_pipe.py
+++ b/tests/test_pipe.py
@@ -86,6 +86,19 @@ def check_ppm_limits(dic, data, dim, limits):
     print(climits)
     assert limits == climits
 
+def read_with_bytes_or_buffer(filename):
+    """ Check reading pipe files from filename, io.BytesIO or bytes buffer """
+    dic, data = ng.pipe.read(filename)
+    # read bytes
+    with open(filename, "rb") as binary_stream:
+        data_bytes = binary_stream.read()
+        bdic, bdata = ng.pipe.read(data_bytes)
+    # read from io.BytesIO
+    with open(filename, "rb") as binary_stream:
+        bdic2, bdata2 = ng.pipe.read(binary_stream)
+    assert dic == bdic == bdic2
+    assert_array_equal(data, bdata)
+    assert_array_equal(data, bdata2)
 
 # tests
 def test_get_fdata_bytes():
@@ -106,7 +119,7 @@ def test_get_data_bytes():
     assert_array_equal(data, bdata)
 
 
-def test_fdata2dic():
+def test_fdata2dic_bytes():
     data_path = os.path.join(DATA_DIR, "nmrpipe_1d", "test.fid") 
     with open(data_path, "rb") as binary_stream:
         bytes_stream = binary_stream.read()
@@ -128,36 +141,39 @@ def test_fdata_data_bytes():
 
 
 def test_read_bytes_1d_time():
-    """ reading NMRPipe data from io.BytesIO binary stream """
+    """ reading NMRPipe data from io.BytesIO binary stream or bytes buffer"""
     data_path = os.path.join(DATA_DIR, "nmrpipe_1d", "test.fid")
-    dic, data = ng.pipe.read(data_path)
-    with open(data_path, "rb") as binary_stream:
-        data_bytes = binary_stream.read()
-        bdic, bdata = ng.pipe.read_bytes(data_bytes)
-    assert dic == bdic
-    assert_array_equal(data, bdata)
+    read_with_bytes_or_buffer(data_path)
 
 
 def test_read_bytes_1d_freq():
-    """ reading NMRPipe data from io.BytesIO binary stream """
+    """ reading NMRPipe data from io.BytesIO binary stream or bytes buffer"""
     data_path = os.path.join(DATA_DIR, "nmrpipe_1d", "test.ft")
-    dic, data = ng.pipe.read(data_path)
-    with open(data_path, "rb") as binary_stream:
-        data_bytes = binary_stream.read()
-        bdic, bdata = ng.pipe.read_bytes(data_bytes)
-    assert dic == bdic
-    assert_array_equal(data, bdata)
+    read_with_bytes_or_buffer(data_path)
+
+
+def test_read_bytes_2d_time():
+    """ reading NMRPipe data from io.BytesIO binary stream """
+    data_path = os.path.join(DATA_DIR, "nmrpipe_2d", "test.fid")
+    read_with_bytes_or_buffer(data_path)
 
 
 def test_read_bytes_2d_freq():
     """ reading NMRPipe data from io.BytesIO binary stream """
     data_path = os.path.join(DATA_DIR, "nmrpipe_2d", "test.ft2")
-    dic, data = ng.pipe.read(data_path)
-    with open(data_path, "rb") as binary_stream:
-        data_bytes = binary_stream.read()
-        bdic, bdata = ng.pipe.read_bytes(data_bytes)
-    assert dic == bdic
-    assert_array_equal(data, bdata)
+    read_with_bytes_or_buffer(data_path)
+
+
+def test_read_bytes_3d_time():
+    """ reading NMRPipe data from io.BytesIO binary stream """
+    data_path = os.path.join(DATA_DIR, "nmrpipe_3d", "full3D.fid")
+    read_with_bytes_or_buffer(data_path)
+
+
+def test_read_bytes_3d_freq():
+    """ reading NMRPipe data from io.BytesIO binary stream """
+    data_path = os.path.join(DATA_DIR, "nmrpipe_3d", "full3D.ft3")
+    read_with_bytes_or_buffer(data_path)
 
 
 def test_1d_time():

--- a/tests/test_pipe.py
+++ b/tests/test_pipe.py
@@ -1,10 +1,12 @@
 """ Tests for the fileio.pipe submodule """
 
 from __future__ import print_function
+from nmrglue.fileio.pipe import fdata2dic
 
 import tempfile
 import os
 import glob
+import io
 
 import numpy as np
 from numpy.testing import assert_array_equal
@@ -13,7 +15,6 @@ import nmrglue as ng
 from setup import DATA_DIR
 
 # subroutines
-
 
 def write_readback(dic, data):
     """ Write out a NMRPipe file and read back in. """
@@ -87,6 +88,78 @@ def check_ppm_limits(dic, data, dim, limits):
 
 
 # tests
+def test_get_fdata_bytes():
+    data_path = os.path.join(DATA_DIR, "nmrpipe_1d", "test.fid") 
+    with open(data_path, "rb") as binary_stream:
+        bytes_stream = binary_stream.read()
+        bdata = ng.fileio.pipe.get_fdata_bytes(bytes_stream)
+    data = ng.fileio.pipe.get_fdata(data_path)
+    assert_array_equal(data, bdata)
+
+
+def test_get_data_bytes():
+    data_path = os.path.join(DATA_DIR, "nmrpipe_1d", "test.fid") 
+    with open(data_path, "rb") as binary_stream:
+        bytes_stream = binary_stream.read()
+        bdata = ng.fileio.pipe.get_data_bytes(bytes_stream)
+    data = ng.fileio.pipe.get_data(data_path)
+    assert_array_equal(data, bdata)
+
+
+def test_fdata2dic():
+    data_path = os.path.join(DATA_DIR, "nmrpipe_1d", "test.fid") 
+    with open(data_path, "rb") as binary_stream:
+        bytes_stream = binary_stream.read()
+        bfdata = ng.fileio.pipe.get_fdata_bytes(bytes_stream)
+    fdata = ng.fileio.pipe.get_fdata(data_path)
+    dic = fdata2dic(fdata)
+    bdic = fdata2dic(bfdata)
+    assert dic == bdic
+
+
+def test_fdata_data_bytes():
+    data_path = os.path.join(DATA_DIR, "nmrpipe_1d", "test.fid") 
+    with open(data_path, "rb") as binary_stream:
+        bytes_stream = binary_stream.read()
+        bdic_data, bdata = ng.fileio.pipe.get_fdata_data_bytes(bytes_stream)
+    dic_data, data = ng.fileio.pipe.get_fdata_data(data_path)
+    assert_array_equal(dic_data, bdic_data)
+    assert_array_equal(data, bdata)
+
+
+def test_read_bytes_1d_time():
+    """ reading NMRPipe data from io.BytesIO binary stream """
+    data_path = os.path.join(DATA_DIR, "nmrpipe_1d", "test.fid")
+    dic, data = ng.pipe.read(data_path)
+    with open(data_path, "rb") as binary_stream:
+        data_bytes = binary_stream.read()
+        bdic, bdata = ng.pipe.read_bytes(data_bytes)
+    assert dic == bdic
+    assert_array_equal(data, bdata)
+
+
+def test_read_bytes_1d_freq():
+    """ reading NMRPipe data from io.BytesIO binary stream """
+    data_path = os.path.join(DATA_DIR, "nmrpipe_1d", "test.ft")
+    dic, data = ng.pipe.read(data_path)
+    with open(data_path, "rb") as binary_stream:
+        data_bytes = binary_stream.read()
+        bdic, bdata = ng.pipe.read_bytes(data_bytes)
+    assert dic == bdic
+    assert_array_equal(data, bdata)
+
+
+def test_read_bytes_2d_freq():
+    """ reading NMRPipe data from io.BytesIO binary stream """
+    data_path = os.path.join(DATA_DIR, "nmrpipe_2d", "test.ft2")
+    dic, data = ng.pipe.read(data_path)
+    with open(data_path, "rb") as binary_stream:
+        data_bytes = binary_stream.read()
+        bdic, bdata = ng.pipe.read_bytes(data_bytes)
+    assert dic == bdic
+    assert_array_equal(data, bdata)
+
+
 def test_1d_time():
     """reading/writing of 1D NMRPipe time domain file"""
     dic, data = ng.pipe.read(

--- a/tests/test_pipe.py
+++ b/tests/test_pipe.py
@@ -105,7 +105,7 @@ def test_get_fdata_bytes():
     data_path = os.path.join(DATA_DIR, "nmrpipe_1d", "test.fid") 
     with open(data_path, "rb") as binary_stream:
         bytes_stream = binary_stream.read()
-        bdata = ng.fileio.pipe.get_fdata_bytes(bytes_stream)
+        bdata = ng.fileio.pipe.get_fdata(bytes_stream)
     data = ng.fileio.pipe.get_fdata(data_path)
     assert_array_equal(data, bdata)
 
@@ -114,7 +114,7 @@ def test_get_data_bytes():
     data_path = os.path.join(DATA_DIR, "nmrpipe_1d", "test.fid") 
     with open(data_path, "rb") as binary_stream:
         bytes_stream = binary_stream.read()
-        bdata = ng.fileio.pipe.get_data_bytes(bytes_stream)
+        bdata = ng.fileio.pipe.get_data(bytes_stream)
     data = ng.fileio.pipe.get_data(data_path)
     assert_array_equal(data, bdata)
 
@@ -123,7 +123,7 @@ def test_fdata2dic_bytes():
     data_path = os.path.join(DATA_DIR, "nmrpipe_1d", "test.fid") 
     with open(data_path, "rb") as binary_stream:
         bytes_stream = binary_stream.read()
-        bfdata = ng.fileio.pipe.get_fdata_bytes(bytes_stream)
+        bfdata = ng.fileio.pipe.get_fdata(bytes_stream)
     fdata = ng.fileio.pipe.get_fdata(data_path)
     dic = fdata2dic(fdata)
     bdic = fdata2dic(bfdata)
@@ -134,7 +134,7 @@ def test_fdata_data_bytes():
     data_path = os.path.join(DATA_DIR, "nmrpipe_1d", "test.fid") 
     with open(data_path, "rb") as binary_stream:
         bytes_stream = binary_stream.read()
-        bdic_data, bdata = ng.fileio.pipe.get_fdata_data_bytes(bytes_stream)
+        bdic_data, bdata = ng.fileio.pipe.get_fdata_data(bytes_stream)
     dic_data, data = ng.fileio.pipe.get_fdata_data(data_path)
     assert_array_equal(dic_data, bdic_data)
     assert_array_equal(data, bdata)

--- a/tests/test_pipe.py
+++ b/tests/test_pipe.py
@@ -86,6 +86,7 @@ def check_ppm_limits(dic, data, dim, limits):
     print(climits)
     assert limits == climits
 
+
 def read_with_bytes_or_buffer(filename):
     """ Check reading pipe files from filename, io.BytesIO or bytes buffer """
     dic, data = ng.pipe.read(filename)


### PR DESCRIPTION
Hi Jonathan,
Thanks for making nmrglue! It's such a wonderful contribution to the NMR community. I have been using it for my work ever since you published your JBNMR paper and it has really empowered my NMR data analyses.

I have a use case whereby I need (want) to read NMRPipe data stored in memory rather than directly from disk. I've added this capability to the `nmrglue.pipe.read` function which can now accept `io.BytesIO` and `bytes` objects containing NMRPipe data. I have written tests which are passing. I think this change should remain entirely compatible with previous versions. Would you be willing to incorporate it? I'm also open to suggestions.
