### PR TITLE
:bug: Fix bug in parse_spinsolve_par_line()

### DIFF
--- a/nmrglue/fileio/spinsolve.py
+++ b/nmrglue/fileio/spinsolve.py
@@ -43,7 +43,7 @@ def parse_spinsolve_par_line(line):
     Parse lines in acqu.par and return a tuple (paramter name, parameter value)
     """
     line = line.strip()  # Drop newline
-    name, value = line.split("=")  # Split at equal sign
+    name, value = line.split("=", maxsplit=1)  # Split at equal sign (and ignore further equals in attribute values)
 
     # remove spaces
     name = name.strip()


### PR DESCRIPTION
If the an attribute contains an equal sign,  then `line.split("=")` returns more than 2 values and causes a
"ValueError: too many values to unpack (expected 2)"

Sorry for this,  I should have tested #151  more

This is particularly annoying since the SpinSolve userData stores custom data on a format that includes equals, so this bug will happen every time the user specify custom userData via the acquisition software.

`userData                            = "some_key=Some value;some_other_key=Other value"`
