### PR TITLE
read nmrPipe data from pathlib.Path object

### DIFF
--- a/nmrglue/fileio/pipe.py
+++ b/nmrglue/fileio/pipe.py
@@ -521,14 +521,16 @@ def read(filename):
     elif hasattr(filename, "read"):
         filename = filename.read()
         filemask = None
-    elif filename.count("%") == 1:
-        filemask = filename
-        filename = filename % 1
-    elif filename.count("%") == 2:
-        filemask = filename
-        filename = filename % (1, 1)
     else:
-        filemask = None
+        filename = str(filename)
+        if filename.count("%") == 1:
+            filemask = filename
+            filename = filename % 1
+        elif filename.count("%") == 2:
+            filemask = filename
+            filename = filename % (1, 1)
+        else:
+            filemask = None
 
     fdata = get_fdata(filename)
     dic = fdata2dic(fdata)

--- a/nmrglue/fileio/pipe.py
+++ b/nmrglue/fileio/pipe.py
@@ -499,7 +499,7 @@ def read(filename):
 
     Parameters
     ----------
-    filename : str | bytes | io.BytesIO
+    filename : str | pathlib.Path | bytes | io.BytesIO
         Filename or filemask of NMRPipe file(s) to read. Binary io.BytesIO stream 
         (e.g. open(filename, "rb")) or bytes buffer can also be provided
 
@@ -520,6 +520,8 @@ def read(filename):
         filemask = None
     elif hasattr(filename, "read"):
         filename = filename.read()
+        filemask = None
+    elif hasattr(filename, "read_bytes") and (filename.name.count("%") == 0):
         filemask = None
     else:
         filename = str(filename)

--- a/tests/test_bruker.py
+++ b/tests/test_bruker.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import tempfile
 import os
 import shutil
+from pathlib import Path
 
 import numpy as np
 from numpy.testing import assert_array_equal
@@ -106,8 +107,10 @@ def test_pprog():
 def test_1d():
     """ reading/writing of 1D bruker data"""
     dic, data = ng.bruker.read(os.path.join(DATA_DIR, "bruker_1d"))
-    assert dic['FILE_SIZE'] == 16384
+    pdic, pdata = ng.bruker.read(Path(DATA_DIR) / "bruker_1d")
+    assert dic['FILE_SIZE'] == pdic["FILE_SIZE"]== 16384
     assert data.shape == (2048, )
+    assert_array_equal(data,pdata)
     assert np.abs(data[20].real - -282.0) <= 0.01
     assert np.abs(data[20].imag - 14.0) <= 0.01
     assert np.abs(data[91].real - -840842.0) <= 0.01

--- a/tests/test_pipe.py
+++ b/tests/test_pipe.py
@@ -6,7 +6,7 @@ from nmrglue.fileio.pipe import fdata2dic
 import tempfile
 import os
 import glob
-import io
+from pathlib import Path
 
 import numpy as np
 from numpy.testing import assert_array_equal
@@ -102,6 +102,15 @@ def read_with_bytes_or_buffer(filename):
     assert_array_equal(data, bdata2)
 
 # tests
+def test_read_pathlib_path():
+    data_path_str = os.path.join(DATA_DIR, "nmrpipe_1d", "test.fid")
+    data_path = Path(DATA_DIR) / "nmrpipe_1d" / "test.fid"
+    dic, data = ng.pipe.read(data_path_str)
+    pdic, pdata = ng.pipe.read(data_path)
+    assert_array_equal(data, pdata)
+    assert dic == pdic
+
+
 def test_get_fdata_bytes():
     data_path = os.path.join(DATA_DIR, "nmrpipe_1d", "test.fid") 
     with open(data_path, "rb") as binary_stream:

--- a/tests/test_pipe.py
+++ b/tests/test_pipe.py
@@ -111,6 +111,15 @@ def test_read_pathlib_path():
     assert dic == pdic
 
 
+def test_read_pathlib_path_template():
+    data_path_template = Path(DATA_DIR) / "nmrpipe_3d" / "data" / "test%03d.fid"
+    data_path_template_str = os.path.join(DATA_DIR, "nmrpipe_3d", "data", "test%03d.fid")
+    dic, data = ng.pipe.read(data_path_template)
+    pdic, pdata = ng.pipe.read(data_path_template_str)
+    assert_array_equal(data, pdata)
+    assert dic == pdic
+
+
 def test_get_fdata_bytes():
     data_path = os.path.join(DATA_DIR, "nmrpipe_1d", "test.fid") 
     with open(data_path, "rb") as binary_stream:


### PR DESCRIPTION
Hi @kaustubhmote, I made a very minor change to the `nmrglue.pipe.read` function so that it deals with `pathlib.Path` objects by converting them back to strings. Not sure whether this is the ideal solution but I wrote a test for it which is passing. Hope that helps and happy to hear alternative ideas.