### PR TITLE
Bugfix for: Cannot import nmrglue with scipy v1.8

### DIFF
--- a/nmrglue/analysis/leastsqbound.py
+++ b/nmrglue/analysis/leastsqbound.py
@@ -4,7 +4,12 @@ import warnings
 
 from numpy import array, take, eye, triu, transpose, dot
 from numpy import empty_like, sqrt, cos, sin, arcsin
-from scipy.optimize.minpack import _check_func
+
+try:
+    from scipy.optimize.minpack import _check_func
+except ImportError:
+    from scipy.optimize._minpack_py import _check_func
+    
 from scipy.optimize import _minpack, leastsq
 
 


### PR DESCRIPTION
This fixes a break in nmrglue due to a reorganization of the `scipy.optimize` submodules in v1.8. The change is backward compatible with previous versions of `scipy`. 