### PR TITLE
Fix typos found by codespell

### DIFF
--- a/nmrglue/analysis/linesh.py
+++ b/nmrglue/analysis/linesh.py
@@ -162,7 +162,7 @@ def fit_spectrum(spectrum, lineshapes, params, amps, bounds, ampbounds,
         :py:func:`fit_NDregion` for details.
     params : list
         P-length list (P is the number of peaks in region) of N-length lists
-        of tuples where each each tuple is the optimiztion starting parameters
+        of tuples where each each tuple is the optimization starting parameters
         for a given peak and dimension lineshape.
     amps : list
         P-length list of amplitudes.

--- a/nmrglue/fileio/fileiobase.py
+++ b/nmrglue/fileio/fileiobase.py
@@ -475,8 +475,8 @@ def trace2index_flat(shape, ntrace):
     """
     Calculate the index of a trace assuming a flat structure
     """
-    # algorithm is to take quotient/remainers of sizes in reverse
-    q = ntrace  # seed quotient with remained
+    # algorithm is to take quotient/remainder of sizes in reverse
+    q = ntrace  # seed quotient with remainder
     index = []
     for s in shape[:0:-1]:  # loop from last size to 2nd size
         q, r = divmod(q, s)

--- a/nmrglue/fileio/pipe.py
+++ b/nmrglue/fileio/pipe.py
@@ -1160,7 +1160,7 @@ def write_slice_3D(filemask, dic, data, shape, slices):
 # -------
 # - When passed x must transposed 1,2 if dic["FDTRANSPOSED"] == 1
 #  (might need to call pipe_proc.tp)
-# - if 'y' passed then cann pipe_proc.tp unless dic["FDTRANSPOED"]
+# - if 'y' passed then can pipe_proc.tp unless dic["FDTRANSPOED"]
 # - save 'good' dictionary and return each loop
 #
 # Looping

--- a/nmrglue/fileio/varian.py
+++ b/nmrglue/fileio/varian.py
@@ -427,7 +427,7 @@ def write_lowmem(dir, dic, data, fid_file="fid", procpar_file="procpar",
     read_lowmem : Read Agilent/Varian using minimal amounts of memory.
 
     """
-    # always find trace ording
+    # always find trace ordering
     if torder is None:
         torder = find_torder(dic["procpar"], data.shape)
 
@@ -450,20 +450,20 @@ def find_torder(dic, shape):
     """
     Find the torder from the procpar dictionary.
 
-    If propar dictionary is incomplete a UserWarning is issued and 'r' is
+    If procpar dictionary is incomplete a UserWarning is issued and 'r' is
     returned.
 
     Parameters
     ----------
     dic : dict
         Dictionary of parameters in the procpar file.
-    shaoe : tuple of ints
+    shape : tuple of ints
         Shape of NMR data.
 
     Returns
     --------
     torder : {'r', 'f', 'o'}
-        File ording for using in :py:func:`read` or :py:func:`write`.
+        File ordering for using in :py:func:`read` or :py:func:`write`.
 
     """
     ndim = len(shape)

--- a/nmrglue/process/pipe_proc.py
+++ b/nmrglue/process/pipe_proc.py
@@ -2430,7 +2430,7 @@ def shuf(dic, data, mode=None):
     'rr2ri' mode ignores any imaginary vector refusing to create a mis-sized
     vector.  'bswap' mode may results in NaN in the data.  'r2i' and 'i2r' not
     implemented.  All modes correctly update minimum and maximum values.  This
-    behavor may differ from NMRPipe's SHUF function.
+    behavior may differ from NMRPipe's SHUF function.
 
     Valid modes are:
 

--- a/nmrglue/process/proc_base.py
+++ b/nmrglue/process/proc_base.py
@@ -237,9 +237,9 @@ def tm(data, t1=0.0, t2=0.0, inv=False, rev=False):
     ============ ================================
     Range        Description
     ============ ================================
-    0:t1         Linear increases from 0.0 to 1.0
+    0:t1         Linear increase from 0.0 to 1.0
     t1:size - t2 Flat with value of 1.0
-    -t2:         Linear descrease from 1.0 to 0.0
+    -t2:         Linear decrease from 1.0 to 0.0
     ============ ================================
 
     Parameters

--- a/nmrglue/util/misc.py
+++ b/nmrglue/util/misc.py
@@ -30,9 +30,9 @@ def pair_similar(dic1, data1, dic2, data2, verb=False, atol=ATOL, rtol=RTOL,
     verb : bool, optional
         Set True for verbose reporting.
     atol : float, optional
-        The absolute tolerent parameter to pass to numpy.allclose.
+        The absolute tolerant parameter to pass to numpy.allclose.
     rtol : float, optional
-        The relative tolenance parameter to pass to numpy.allclose.
+        The relative tolerance parameter to pass to numpy.allclose.
 
     Returns
     -------
@@ -61,9 +61,9 @@ def isdatasimilar(data1, data2, verb=False, atol=ATOL, rtol=RTOL):
     verb : bool, optional
         Set True for verbose reporting.
     atol : float, optional
-        The absolute tolerent parameter to pass to numpy.allclose.
+        The absolute tolerant parameter to pass to numpy.allclose.
     rtol : float, optional
-        The relative tolenance parameter to pass to numpy.allclose.
+        The relative tolerance parameter to pass to numpy.allclose.
 
     Returns
     -------


### PR DESCRIPTION
I have left out `seperate`, addressed in #139.