### PR TITLE
Partially revert 1802772 and bbeb8aa

### DIFF
--- a/nmrglue/util/xcpy.py
+++ b/nmrglue/util/xcpy.py
@@ -155,15 +155,17 @@ def write_cfg(outfile, infile=None):
             cpyname, scripts_location = read_cfg(infile)
         except OSError:
             if exists(infile):
-                errmsg = f"""
-                    The following configuration was found in the file {infile}:
+                errmsg = """
+                    The following configuration was found in the file {}:
 
-                    {show_config(infile, printing=False)}
+                    {}
 
                     These settings are likely incorrect.
                     You can enter the correct settings at the next dialog box.
                     Press 'Close' to continue.
-                    """
+                    """.format(
+                    infile, show_config(infile, printing=False)
+                )
                 MSG(errmsg)
 
             cpyname, scripts_location = read_cfg(infile, check_python=False)
@@ -206,7 +208,7 @@ def exists(filename, raise_error=False):
     if os.path.exists(filename):
         return True
     elif raise_error:
-        raise Exception(f"{filename} not found")
+        raise Exception("{} not found".format(filename))
     else:
         return False
 
@@ -305,17 +307,19 @@ def verify_python(command):
 
     """
     if not os.path.exists(command):
-        raise OSError(f"The command {command} does not seem to exist")
+        raise OSError("The command {} does not seem to exist".format(command))
 
     command = command.split(os.sep)[-1]
     if command.lower().find("python") != 0:
 
-        errmsg = f"""
-            {command} does not seem to be a valid python file.
+        errmsg = """
+            {} does not seem to be a valid python file.
             Please check the configuration file using 'xcpy --config',
             or change the configuration file using 'xcpy --settings'
             This attempt will be aborted.
-            """
+            """.format(
+            command
+        )
 
         raise OSError(errmsg)
 
@@ -369,12 +373,14 @@ def main():
     # if it does not, alert the user and open up a dialog box to write it out
     elif not os.path.exists(config_file):
         MSG(
-            f"""
+            """
             Configuration file does not exist.
             An input box will be opened next to write it.
-            Alternately, it can be manually edited at {config_file}.
+            Alternately, it can be manually edited at {}.
             Press 'Close' to continue.
-            """
+            """.format(
+                config_file
+            )
         )
         write_cfg(config_file)
 
@@ -449,10 +455,10 @@ def main():
 
             # executed should be false iff no script was found
             if not executed:
-                scriptname = argv[-1] + ".py"
-                folders = "\n".join(folders)
                 raise Exception(
-                    f"The file {scriptname} was not found in the following folders:\n\n{folders}"
+                    "The file {} was not found in the following folders:\n\n{}".format(
+                        argv[-1] + ".py", "\n".join(folders)
+                    )
                 )
 
         # handle errors and print messages from cpython

--- a/nmrglue/util/xcpy_test.py
+++ b/nmrglue/util/xcpy_test.py
@@ -11,18 +11,18 @@ def main():
 
     try:
         name, curdir, curexpno, curprocno = sys.argv
-        message = f"""
-        Welcome to Python {python}.
-        The current directory is set to {curdir}
-        EXPNO {curexpno} is currently open at PROCNO {curprocno}
-        """
+        message = """
+        Welcome to Python {}.
+        The current directory is set to {}
+        EXPNO {} is currently open at PROCNO {}
+        """.format(python, curdir, curexpno, curprocno)
 
     except ValueError:
-        message = f"""
-        Welcome to Python {python}.
-        No directory is currently open,
+        message = """
+        Welcome to Python {}.
+        No directory is currently open, 
         or none was passed on to this script.
-        """
+        """.format(python)
 
     print(message)
 


### PR DESCRIPTION
The xcpy module is used within TopSpin, which includes Jython, which implements Python 2.

Remove changes applied to `nmrglue/util/xcpy.py` and `nmrglue/util/xcpy_test.py` in #178 and #179.

See https://github.com/jjhelmus/nmrglue/pull/179#issuecomment-1340210384.