### PR TITLE
Changed 'np.float' to 'float' in peakpick.py line 329

### DIFF
--- a/nmrglue/analysis/peakpick.py
+++ b/nmrglue/analysis/peakpick.py
@@ -326,7 +326,7 @@ def pack_table(locations, cluster_ids=None, scales=None, amps=None,
     ndim = len(locations[0])
     anames = axis_names[-ndim:]
 
-    dt = [(a + "_AXIS", np.float) for a in anames]
+    dt = [(a + "_AXIS", float) for a in anames]
     rec = np.rec.array(locations, dtype=dt)
 
     if cluster_ids is not None:


### PR DESCRIPTION
Changed 'np.float' to 'float' in peakpick.py line 329 to fix the np.analysis.peakpick.pick() function. NumPy deprecated the np.float function in numpy 1.20.0 which broke the ng.analysis.peakpick.pick() function giving an error (see nmrglue issue #192). Changing 'np.float' to 'float' is the recommended fix by NumPy as it "will not modify any behavior and is safe." Using the float() function instead of np.float() looks to be consistent with the rest of the code in peakpick.py.