### PR TITLE
Fixes for deprecations in newer versions of numpy

### DIFF
--- a/nmrglue/analysis/peakpick.py
+++ b/nmrglue/analysis/peakpick.py
@@ -326,7 +326,7 @@ def pack_table(locations, cluster_ids=None, scales=None, amps=None,
     ndim = len(locations[0])
     anames = axis_names[-ndim:]
 
-    dt = [(a + "_AXIS", np.float) for a in anames]
+    dt = [(a + "_AXIS", float) for a in anames]
     rec = np.rec.array(locations, dtype=dt)
 
     if cluster_ids is not None:
@@ -367,7 +367,7 @@ def guess_params_slice(data, location, seg_slice, ls_classes):
 
     """
     # find the rectangular region around the segment
-    region = data[seg_slice]
+    region = data[slice(*seg_slice)]
     edge = [s.start for s in seg_slice]
     rlocation = [l - s.start for l, s in zip(location, seg_slice)]
 

--- a/nmrglue/fileio/convert.py
+++ b/nmrglue/fileio/convert.py
@@ -92,7 +92,7 @@ class converter:
             s = [slice(None, None, None)] * data.ndim
             for i in range(data.ndim - 1):
                 s[i] = slice(1, None, 2)
-                data[s] = -data[s]
+                data[*s] = -data[*s]
                 s[i] = slice(None, None, None)
 
         if "realfactor" in self._iproc:
@@ -107,7 +107,7 @@ class converter:
             s = [slice(None, None, None)] * data.ndim
             for i in range(data.ndim - 1):
                 s[i] = slice(1, None, 2)
-                data[s] = -data[s]
+                data[*s] = -data[*s]
                 s[i] = slice(None, None, None)
 
         if "realfactor" in self._oproc:

--- a/nmrglue/fileio/convert.py
+++ b/nmrglue/fileio/convert.py
@@ -92,7 +92,7 @@ class converter:
             s = [slice(None, None, None)] * data.ndim
             for i in range(data.ndim - 1):
                 s[i] = slice(1, None, 2)
-                data[*s] = -data[*s]
+                data[tuple(s)] = -data[tuple(s)]
                 s[i] = slice(None, None, None)
 
         if "realfactor" in self._iproc:
@@ -107,7 +107,7 @@ class converter:
             s = [slice(None, None, None)] * data.ndim
             for i in range(data.ndim - 1):
                 s[i] = slice(1, None, 2)
-                data[*s] = -data[*s]
+                data[tuple(s)] = -data[tuple(s)]
                 s[i] = slice(None, None, None)
 
         if "realfactor" in self._oproc:


### PR DESCRIPTION
This PR fixes the following:

1. `np.float` is now deprecated, which breaks peak-picking (#192). This is replaced by a call to `float`.
2. Use of lists as multiple slices is not allowed anymore. This broke several data conversion routines (#195). Lists are unpacked before being fed to the array as slices.

These changes are compatible with previous versions of numpy and nmrglue.