### PR TITLE
Added function to read Bruker's vd list

### DIFF
--- a/nmrglue/fileio/bruker.py
+++ b/nmrglue/fileio/bruker.py
@@ -2651,3 +2651,44 @@ def read_nuslist(dirc=".", fname="nuslist"):
 
     return converted_nuslist
 
+# Read Bruker VD delays list
+
+def read_vdlist(dir):
+    """
+    This function reads a Bruker 'vdlist' file from a specified directory and returns a list of variable delay (vd) times in seconds. 
+    The 'vdlist' file contains delay times typically used in NMR relaxation experiments, typically ns, ms, ms, or s. This function converts all delay times to seconds for consistency.
+
+    Parameters
+    ----------
+    dir : str
+        The directory path where the 'vdlist' file is located.
+
+    Returns
+    -------
+    vdlist : list
+        A list of delay times in seconds. Each delay time is a float.
+    """
+    # check that vdlist file exists
+    vdlist_file = os.path.join(dir, "vdlist")
+    if os.path.isfile(vdlist_file) is not True:
+        raise OSError("The 'vdlist' file was not found in the directory: %s. Please ensure that you have provided the 'acqu' directory, not the 'pdata' directory." % (dir))
+    
+    # read vdlist file
+    with open(vdlist_file, 'r') as f:
+        vdlist = f.readlines()
+        for i in range(len(vdlist)):
+            if 'n' in vdlist[i]:
+                vdlist[i] = vdlist[i].replace('n', 'e-9')
+            elif 'u' in vdlist[i]:
+                vdlist[i] = vdlist[i].replace('u', 'e-6')
+            elif 'm' in vdlist[i]:
+                vdlist[i] = vdlist[i].replace('m', 'e-3')
+            elif 's' in vdlist[i]:
+                vdlist[i] = vdlist[i].replace('s', 'e0')
+            else:
+                vdlist[i] = vdlist[i].replace('\n', '')
+
+    # convert to floats
+    vdlist = [float(i) for i in vdlist]
+
+    return vdlist


### PR DESCRIPTION
I added a function to nmrglue's bruker.py file, which allows for the reading of the **vd delay list** file that is required for relaxation studies, as well as optimization for certain rotor-synchronized experiments. The vd delay list file typically contains numerical values, sometimes accompanied by letters such as n, u, or m, indicating nano, micro, and milliseconds. The function _read_vdlist_ handles this and converts the values into a list of floats.