### PR TITLE
BugFix: directory variable in read_vdlist

### DIFF
--- a/nmrglue/fileio/bruker.py
+++ b/nmrglue/fileio/bruker.py
@@ -2653,7 +2653,8 @@ def read_nuslist(dirc=".", fname="nuslist"):
 
 # Read Bruker VD delays list
 
-def read_vdlist(dir):
+
+def read_vdlist(dirc, fname='vdlist'):
     """
     This function reads a Bruker 'vdlist' file from a specified directory and
     returns a list of variable delay (vd) times in seconds.
@@ -2663,22 +2664,28 @@ def read_vdlist(dir):
 
     Parameters
     ----------
-    dir : str
+    dirc : str
         The directory path where the 'vdlist' file is located.
+    fname : str
+        name of the vdlist file, by default 'vdlist'
 
     Returns
     -------
     vdlist : list
         A list of delay times in seconds. Each delay time is a float.
+
+    Raises
+    ------
+    FileNotFoundError 
+        if the vdlist file is absent
+
     """
-    
     # Check that vdlist file exists
-    vdlist_file = os.path.join(dir, "vdlist")
+    vdlist_file = os.path.join(dirc, fname)
     if os.path.isfile(vdlist_file) is not True:
-        raise OSError(
-            "The 'vdlist' file was not found in the directory: {}. Please ensure"
-            " that you have provided the 'acqu' directory, not the 'pdata'"
-            " directory.".format(directory)
+        raise FileNotFoundError(
+            f"The 'vdlist' file ({fname}) was not found in the directory: {dirc}. Please ensure"
+            " that you have provided the 'acqu' directory, not the 'pdata' directory."
         )
         
     # Read vdlist file

--- a/tests/test_bruker_with_test_data.py
+++ b/tests/test_bruker_with_test_data.py
@@ -222,4 +222,15 @@ def test_read_nuslist():
 
     os.remove("tmp_nuslist")
 
-    pass
+
+def test_read_vdlist():
+    """ reading vdlist """
+    with open("tmp_vdlist", "w") as f:
+        f.write("""1n\n10n\n50u\n20u\n30m\n50m\n1\n2\n""")
+
+    vdlist = ng.bruker.read_vdlist(".", fname="tmp_vdlist")
+    true_vdlist = [1e-9, 10e-9, 50e-6, 20e-6, 30e-3, 50e-3, 1.0, 2.0] 
+    for i, j in zip(vdlist, true_vdlist):
+        assert i -j < 1e-10
+
+    os.remove("tmp_vdlist")


### PR DESCRIPTION
I somehow missed that the final version of PR #212 had a bug in directory variable name. I am fixing this, as well as adding a test to check this function. Plus some cleanup of the error message.