### PR TITLE
Ensure Consistent Output Structure for _parse_xy_xy

### DIFF
--- a/nmrglue/fileio/bruker.py
+++ b/nmrglue/fileio/bruker.py
@@ -1904,7 +1904,12 @@ def read_jcamp(filename):
     with open(filename, 'r') as f:
         while True:     # loop until end of file is found
 
-            line = f.readline().rstrip()    # read a line
+            try:
+                line = f.readline().rstrip()    # read a line
+            except Exception as e:
+                warn("Unable read line, leave it as a comment")
+                line = "$$"
+
             if line == '':      # end of file found
                 break
 

--- a/nmrglue/fileio/jcampdx.py
+++ b/nmrglue/fileio/jcampdx.py
@@ -573,6 +573,7 @@ def read(filename, show_all_data=False, read_err=None):
 
     # remove data tables from dic
     try:
+        dic['XYDATA_OLD'] = dic["XYDATA"]
         del dic["XYDATA"]
     except KeyError:
         pass

--- a/nmrglue/fileio/jcampdx.py
+++ b/nmrglue/fileio/jcampdx.py
@@ -355,16 +355,21 @@ def _parse_pseudo(datalines):
 
 def _parse_xy_xy(datalines):
     pts = []
+    len_group_data = 0
     for dataline in datalines:
         if not dataline:
             continue
         xy_re = re.compile('[^ ][0-9\.]+, [0-9\.]+')
         group_data = re.findall(xy_re, dataline)
+        len_group_data = len(group_data)
         for data in group_data:
             x, y = data.split(', ')
             pts.append([float(x), float(y)])
 
-    return [pts]
+    if len_group_data > 1:
+      return [pts]
+    else:
+      return pts
 
 
 def _parse_data(datastring):

--- a/nmrglue/fileio/jcampdx.py
+++ b/nmrglue/fileio/jcampdx.py
@@ -151,7 +151,7 @@ def _detect_format(dataline):
     firstvalue_re = re.compile(
         "(\s)*([+-]?\d+\.?\d*|[+-]?\.\d+)([eE][+-]?\d+)?(\s)*")
 
-    xy_re = re.compile('^[0-9\.]+, [0-9\.]+$')
+    xy_re = re.compile('^[0-9\.]+, [0-9\.]+')
 
     index = firstvalue_re.match(dataline).end()
     if index is None:
@@ -358,10 +358,13 @@ def _parse_xy_xy(datalines):
     for dataline in datalines:
         if not dataline:
             continue
-        x, y = dataline.split(', ')
-        pts.append([float(x), float(y)])
+        xy_re = re.compile('[^ ][0-9\.]+, [0-9\.]+')
+        group_data = re.findall(xy_re, dataline)
+        for data in group_data:
+            x, y = data.split(', ')
+            pts.append([float(x), float(y)])
 
-    return pts
+    return [pts]
 
 
 def _parse_data(datastring):
@@ -498,6 +501,17 @@ def _getdataarray(dic, show_all_data=False):
                      returning first one only")
         except KeyError:
             warn("XYDATA not found ")
+
+    if data is None:  # PEAK TABLE
+        try:
+            valuelist = dic["PEAKTABLE"]
+            if len(valuelist) == 1:
+                data, datatype = _parse_data(valuelist[0])
+            else:
+                warn("Multiple PEAKTABLE arrays in JCAMP-DX file, \
+                     returning first one only")
+        except KeyError:
+            warn("PEAKTABLE not found ")
 
     # apply YFACTOR to data if available
     if is_ntuples:

--- a/nmrglue/fileio/jcampdx.py
+++ b/nmrglue/fileio/jcampdx.py
@@ -417,7 +417,7 @@ def find_yfactors(dic):
     return (factor_r, factor_i)
 
 
-def _getdataarray(dic):
+def _getdataarray(dic, show_all_data=False):
     '''
     Main function for data array parsing, input is the
     raw dictionary from _readrawdic
@@ -447,19 +447,23 @@ def _getdataarray(dic):
                     idatalist.append(data)
                 else:
                     rdatalist.append(data)
-            if len(rdatalist) > 1:
-                warn("NTUPLES: multiple real arrays, returning first one only")
-            if len(idatalist) > 1:
-                warn("NTUPLES: multiple imaginary arrays, \
-                     returning first one only")
-            if rdatalist:
-                if idatalist:
-                    data = [rdatalist[0], idatalist[0]]
-                else:
-                    data = rdatalist[0]
+
+            if show_all_data:
+                data = { 'real': rdatalist, 'imaginary': idatalist }
             else:
-                if idatalist:
-                    data = [None, idatalist[0]]
+                if len(rdatalist) > 1:
+                    warn("NTUPLES: multiple real arrays, returning first one only")
+                if len(idatalist) > 1:
+                    warn("NTUPLES: multiple imaginary arrays, \
+                         returning first one only")
+                if rdatalist:
+                    if idatalist:
+                        data = [rdatalist[0], idatalist[0]]
+                    else:
+                        data = rdatalist[0]
+                else:
+                    if idatalist:
+                        data = [None, idatalist[0]]
 
     if data is None:  # XYDATA
         try:
@@ -477,6 +481,11 @@ def _getdataarray(dic):
         yfactor_r, yfactor_i = find_yfactors(dic)
         if yfactor_r is None or yfactor_r is None:
             warn("NTUPLES: YFACTORs not applied, parsing failed")
+        elif show_all_data:
+            for i, _ in enumerate(data['real']):
+                data['real'][i] = data['real'][i] * yfactor_r
+            for i, _ in enumerate(data['imaginary']):
+                data['imaginary'][i] = data['imaginary'][i] * yfactor_i
         else:
             data[0] = data[0] * yfactor_r
             data[1] = data[1] * yfactor_i
@@ -492,7 +501,7 @@ def _getdataarray(dic):
     return data
 
 
-def read(filename):
+def read(filename, show_all_data=False):
     """
     Read JCAMP-DX file
 
@@ -518,7 +527,7 @@ def read(filename):
     dic = _readrawdic(filename)
 
     # find and parse NMR data array from raw dic
-    data = _getdataarray(dic)
+    data = _getdataarray(dic, show_all_data)
 
     # remove data tables from dic
     try:

--- a/nmrglue/fileio/jcampdx.py
+++ b/nmrglue/fileio/jcampdx.py
@@ -151,6 +151,8 @@ def _detect_format(dataline):
     firstvalue_re = re.compile(
         "(\s)*([+-]?\d+\.?\d*|[+-]?\.\d+)([eE][+-]?\d+)?(\s)*")
 
+    xy_re = re.compile('^[0-9\.]+, [0-9\.]+$')
+
     index = firstvalue_re.match(dataline).end()
     if index is None:
         return -1
@@ -165,6 +167,10 @@ def _detect_format(dataline):
         return 1
     if firstchar in _SQZ_DIGITS:
         return 1
+
+    if re.search(xy_re, dataline):
+        return 2
+
     return 0
 
 
@@ -347,6 +353,17 @@ def _parse_pseudo(datalines):
     return data
 
 
+def _parse_xy_xy(datalines):
+    pts = []
+    for dataline in datalines:
+        if not dataline:
+            continue
+        x, y = dataline.split(', ')
+        pts.append([float(x), float(y)])
+
+    return pts
+
+
 def _parse_data(datastring):
     '''
     Creates numpy array from datalines
@@ -364,6 +381,8 @@ def _parse_data(datastring):
         data = _parse_pseudo(datalines)
     elif mode == 0:
         data = _parse_affn_pac(datalines)
+    elif mode == 2:
+        data = _parse_xy_xy(datalines)
     else:
         return None
     if data is None:

--- a/nmrglue/fileio/jcampdx.py
+++ b/nmrglue/fileio/jcampdx.py
@@ -371,12 +371,7 @@ def _parse_xy_xy(datalines):
             clean_data = clean_data.replace(';', '')
             x, y = clean_data.split(',')
             pts.append([float(x), float(y)])
-
-    if len_group_data > 1:
-      return [pts]
-    else:
-      return pts
-
+    return [pts]
 
 def _parse_data(datastring):
     '''

--- a/nmrglue/fileio/jcampdx.py
+++ b/nmrglue/fileio/jcampdx.py
@@ -37,14 +37,14 @@ def _getkey(keystr):
             .replace("-", "").replace("_", "").replace("/", ""))
 
 
-def _readrawdic(filename):
+def _readrawdic(filename, read_err=None):
     '''
     Reads JCAMP-DX file to key-value dictionary, from which
     actual data is separated later.
     '''
 
     dic = {"_comments": []}  # create empty dictionary
-    filein = open(filename, 'r')
+    filein = open(filename, 'r', errors=read_err)
 
     currentkey = None
     currentvaluestrings = []
@@ -501,7 +501,7 @@ def _getdataarray(dic, show_all_data=False):
     return data
 
 
-def read(filename, show_all_data=False):
+def read(filename, show_all_data=False, read_err=None):
     """
     Read JCAMP-DX file
 
@@ -524,7 +524,7 @@ def read(filename, show_all_data=False):
     # first read everything (including data array) to "raw" dictionary,
     # in which data values are read as raw strings including whitespace
     # and newlines
-    dic = _readrawdic(filename)
+    dic = _readrawdic(filename, read_err)
 
     # find and parse NMR data array from raw dic
     data = _getdataarray(dic, show_all_data)

--- a/nmrglue/fileio/jcampdx.py
+++ b/nmrglue/fileio/jcampdx.py
@@ -368,6 +368,10 @@ def _parse_data(datastring):
     '''
     Creates numpy array from datalines
     '''
+    probe_data = datastring[80:320]
+    if ',' in probe_data and not('.' in probe_data): # fix comma as decimal points
+        datastring = datastring.replace(',', '.')
+
     datalines = datastring.split("\n")
     headerline = datalines[0]
 


### PR DESCRIPTION
This pull request modifies the _parse_xy_xy function in nmrglue to ensure consistent data output, regardless of the structure of the input data. Previously, the function returned a different structure based on the number of data points in a line, leading to inconsistencies in downstream processing.

The updated function now always returns a consistent structure ([[x, y], ...] wrapped in a list) to align with expected behavior.

**Changes Made**
Removed the conditional check on len_group_data at the end of the function.
The function now consistently returns [[x, y], ...] wrapped in a list, regardless of the input format.

**Dependency Note**
This change must be made in tandem with [ChemSpectra Backend PR #220](https://github.com/ComPlat/chem-spectra-app/pull/220), which addresses related inconsistencies in the Spectra Viewer.

**The backend PR resolves:**
Normalization of input data to handle inconsistent array dimensions.
Issues with parsing 3D data arrays with a single initial dimension (e.g., shape (1, N, 2)) by converting them to the expected 2D format (N, 2).

**Both changes together ensure that:**
JCAMP and ESI Mass files are parsed and displayed consistently in the ChemSpectra Viewer.
File parsing does not fail due to unexpected data structures.

**Testing**
Verify that _parse_xy_xy outputs the same structure for all valid inputs, regardless of the number of data points per line.
Confirm that related file types (e.g., JCAMP, ESI Mass) work correctly in the Spectra Viewer with the ChemSpectra backend changes applied.

**Issue Reference**
[ChemSpectra Issue #218: Problem with opening ESI Mass Files in Spectra Viewer](https://github.com/ComPlat/chem-spectra-app/pull/220)