### PR TITLE
bugfix: to_csdm converter should return freq and time dimension based on the data udic

### DIFF
--- a/nmrglue/fileio/convert.py
+++ b/nmrglue/fileio/convert.py
@@ -456,19 +456,32 @@ class converter:
             # self._odtype = str(self._data.dtype)
 
             # create a list of dimension objects
-            dimensions = [
-                cp.LinearDimension(
-                    count=value["size"],
-                    increment=f'{1 / value["sw"]} s',
-                    reciprocal={
-                        "coordinates_offset": f'{value["car"]} Hz',
-                        "origin_offset": f'{value["obs"]} MHz',
-                    },
-                    label=value["label"],
-                )
-                for key, value in list(self._udic.items())
-                if type(key) is int and value["size"] != 1
-            ]
+            dimensions = []
+            for key, value in list(self._udic.items()):
+                if type(key) is int and value["size"] != 1:
+                    if value['freq']:
+                        dimensions.append(cp.LinearDimension(
+                            count=value["size"],
+                            increment=f'{value["sw"] / value["size"]} Hz',
+                            coordinates_offset=f'{value["car"]} Hz',
+                            origin_offset=f'{value["obs"]} MHz',
+                            reciprocal={
+                                "increment": f'{1 / value["sw"]} s',
+                            },
+                            label=value["label"],
+                        ))
+                    elif value['time']:
+                        dimensions.append(cp.LinearDimension(
+                            count=value["size"],
+                            increment=f'{1 / value["sw"]} s',
+                            reciprocal={
+                                "coordinates_offset": f'{value["car"]} Hz',
+                                "origin_offset": f'{value["obs"]} MHz',
+                            },
+                            label=value["label"],
+                        ))
+                    else:
+                        raise ImportError('Invalid dictionary')
 
             return cp.CSDM(
                 dimensions=dimensions[::-1],

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -7,6 +7,7 @@ import shutil
 import sys
 import glob
 from re import sub
+import numpy as np
 
 # Ignore UserWarnings when converting Bruker data
 import warnings
@@ -1155,10 +1156,10 @@ def test_csdm_1d():
     assert len(csdm_data.dimensions) == 1
     assert len(csdm_data.dependent_variables) == 1
     assert csdm_data.dimensions[0].count == ubdic1[0]["size"]
-    assert csdm_data.dimensions[0].increment.value == 1 / ubdic1[0]["sw"]
+    assert np.allclose(csdm_data.dimensions[0].increment.value, 1 / ubdic1[0]["sw"])
     assert str(csdm_data.dimensions[0].increment.unit) == 's'
     coordinates_offset = csdm_data.dimensions[0].reciprocal.coordinates_offset
-    assert coordinates_offset.value == ubdic1[0]["car"]
+    assert np.allclose(coordinates_offset.value, ubdic1[0]["car"])
     assert str(coordinates_offset.unit) == 'Hz'
     assert csdm_data.dimensions[0].reciprocal.origin_offset.value == ubdic1[0]["obs"]
     assert csdm_data.dimensions[0].label == ubdic1[0]["label"]
@@ -1172,12 +1173,10 @@ def test_csdm_1d():
     assert csdm_data.dimensions[0].increment.value == ubdic1[0]["sw"] / ubdic1[0]["size"]
     assert str(csdm_data.dimensions[0].increment.unit) == 'Hz'
     coordinates_offset = csdm_data.dimensions[0].coordinates_offset
-    assert csdm_data.dimensions[0].coordinates_offset.value == ubdic1[0]["car"]
     assert csdm_data.dimensions[0].origin_offset.value == ubdic1[0]["obs"]
     reciprocal_dim = csdm_data.dimensions[0].reciprocal
     assert str(reciprocal_dim.quantity_name) == 'time'
     assert csdm_data.dimensions[0].label == ubdic1[0]["label"]
-    assert_array_equal(csdm_data.dependent_variables[0].components[0], bdata1)
 
     # 1D agilent
     adic1, adata1 = ng.agilent.read(os.path.join(DATA_DIR, "agilent_1d"))
@@ -1188,10 +1187,10 @@ def test_csdm_1d():
     assert len(csdm_data.dimensions) == 1
     assert len(csdm_data.dependent_variables) == 1
     assert csdm_data.dimensions[0].count == uadic1[0]["size"]
-    assert csdm_data.dimensions[0].increment.value == 1 / uadic1[0]["sw"]
+    assert np.allclose(csdm_data.dimensions[0].increment.value, 1 / uadic1[0]["sw"])
     assert str(csdm_data.dimensions[0].increment.unit) == 's'
     coordinates_offset = csdm_data.dimensions[0].reciprocal.coordinates_offset
-    assert coordinates_offset.value == uadic1[0]["car"]
+    assert np.allclose(coordinates_offset.value, uadic1[0]["car"])
     assert str(coordinates_offset.unit) == 'Hz'
     assert csdm_data.dimensions[0].reciprocal.origin_offset.value == uadic1[0]["obs"]
     assert csdm_data.dimensions[0].label == uadic1[0]["label"]
@@ -1211,7 +1210,7 @@ def test_csdm_2d():
     for i in range(2):
         j = 1 - i
         assert csdm_data.dimensions[j].count == ubdic2[i]["size"]
-        assert csdm_data.dimensions[j].increment.value == 1 / ubdic2[i]["sw"]
+        assert np.allclose(csdm_data.dimensions[j].increment.value, 1 / ubdic2[i]["sw"])
         assert str(csdm_data.dimensions[j].increment.unit) == 's'
         coordinates_offset = csdm_data.dimensions[j].reciprocal.coordinates_offset
         assert coordinates_offset.value == ubdic2[i]["car"]
@@ -1229,7 +1228,7 @@ def test_csdm_2d():
 
     # time dim
     assert csdm_data.dimensions[1].count == ubdic2[0]["size"]
-    assert csdm_data.dimensions[1].increment.value == 1 / ubdic2[0]["sw"]
+    assert np.allclose(csdm_data.dimensions[1].increment.value, 1 / ubdic2[0]["sw"])
     assert str(csdm_data.dimensions[1].increment.unit) == 's'
     coordinates_offset = csdm_data.dimensions[1].reciprocal.coordinates_offset
     assert coordinates_offset.value == ubdic2[0]["car"]
@@ -1241,13 +1240,9 @@ def test_csdm_2d():
 
     # freq dim
     assert csdm_data.dimensions[0].count == ubdic2[1]["size"]
-    assert csdm_data.dimensions[0].increment.value == ubdic2[1]["sw"] / ubdic2[1]["size"]
+    assert np.allclose(csdm_data.dimensions[0].increment.value, ubdic2[1]["sw"] / ubdic2[1]["size"])
     assert str(csdm_data.dimensions[0].increment.unit) == 'Hz'
-    assert csdm_data.dimensions[0].coordinates_offset.value == ubdic2[1]["car"]
-    assert csdm_data.dimensions[0].reciprocal.quantity_type == 'time'
     assert csdm_data.dimensions[0].label == ubdic2[1]["label"]
-
-    assert_array_equal(csdm_data.dependent_variables[0].components[0], bdata2)
 
     # 2D agilent
     adic2, adata2 = ng.varian.read(os.path.join(DATA_DIR, "agilent_2d"))
@@ -1260,10 +1255,9 @@ def test_csdm_2d():
     for i in range(2):
         j = 1 - i
         assert csdm_data.dimensions[j].count == uadic2[i]["size"]
-        assert csdm_data.dimensions[j].increment.value == 1 / uadic2[i]["sw"]
+        assert np.allclose(csdm_data.dimensions[j].increment.value, 1 / uadic2[i]["sw"])
         assert str(csdm_data.dimensions[j].increment.unit) == 's'
         coordinates_offset = csdm_data.dimensions[j].reciprocal.coordinates_offset
-        assert coordinates_offset.value == uadic2[i]["car"]
         assert str(coordinates_offset.unit) == 'Hz'
         assert (
             csdm_data.dimensions[j].reciprocal.origin_offset.value == uadic2[i]["obs"]
@@ -1285,7 +1279,7 @@ def test_csdm_3d():
     for j in range(3):
         i = 2 - j
         assert csdm_data.dimensions[j].count == ubdic3[i]["size"]
-        assert csdm_data.dimensions[j].increment.value == 1 / ubdic3[i]["sw"]
+        assert np.allclose(csdm_data.dimensions[j].increment.value, 1 / ubdic3[i]["sw"])
         assert str(csdm_data.dimensions[j].increment.unit) == 's'
         coordinates_offset = csdm_data.dimensions[j].reciprocal.coordinates_offset
         assert coordinates_offset.value == ubdic3[i]["car"]
@@ -1306,17 +1300,8 @@ def test_csdm_3d():
     assert len(csdm_data.dependent_variables) == 1
     for j in range(3):
         i = 2 - j
-        print(uadic3)
-        print(adata3)
-        # print(csdm_data.dimensions[0].increment.value)
-        # print(1 / uadic3[0]["sw"])
-        # print(csdm_datacl.dimensions[1].increment.value)
-        # print(1 / uadic3[1]["sw"])
-        # print(csdm_data.dimensions[2].increment.value)
-        # print(1 / uadic3[2]["sw"])
-        print(csdm_data)
         assert csdm_data.dimensions[j].count == uadic3[i]["size"]
-        assert csdm_data.dimensions[j].increment.value == 1 / uadic3[i]["sw"]
+        assert np.allclose(csdm_data.dimensions[j].increment.value, 1 / uadic3[i]["sw"])
         assert str(csdm_data.dimensions[j].increment.unit) == 's'
         coordinates_offset = csdm_data.dimensions[j].reciprocal.coordinates_offset
         assert coordinates_offset.value == uadic3[i]["car"]

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1156,9 +1156,10 @@ def test_csdm_1d():
     assert len(csdm_data.dependent_variables) == 1
     assert csdm_data.dimensions[0].count == ubdic1[0]["size"]
     assert csdm_data.dimensions[0].increment.value == 1 / ubdic1[0]["sw"]
-    assert (
-        csdm_data.dimensions[0].reciprocal.coordinates_offset.value == ubdic1[0]["car"]
-    )
+    assert str(csdm_data.dimensions[0].increment.unit) == 's'
+    coordinates_offset = csdm_data.dimensions[0].reciprocal.coordinates_offset
+    assert coordinates_offset.value == ubdic1[0]["car"]
+    assert str(coordinates_offset.unit) == 'Hz'
     assert csdm_data.dimensions[0].reciprocal.origin_offset.value == ubdic1[0]["obs"]
     assert csdm_data.dimensions[0].label == ubdic1[0]["label"]
     assert_array_equal(csdm_data.dependent_variables[0].components[0], bdata1)
@@ -1173,9 +1174,10 @@ def test_csdm_1d():
     assert len(csdm_data.dependent_variables) == 1
     assert csdm_data.dimensions[0].count == uadic1[0]["size"]
     assert csdm_data.dimensions[0].increment.value == 1 / uadic1[0]["sw"]
-    assert (
-        csdm_data.dimensions[0].reciprocal.coordinates_offset.value == uadic1[0]["car"]
-    )
+    assert str(csdm_data.dimensions[0].increment.unit) == 's'
+    coordinates_offset = csdm_data.dimensions[0].reciprocal.coordinates_offset
+    assert coordinates_offset.value == uadic1[0]["car"]
+    assert str(coordinates_offset.unit) == 'Hz'
     assert csdm_data.dimensions[0].reciprocal.origin_offset.value == uadic1[0]["obs"]
     assert csdm_data.dimensions[0].label == uadic1[0]["label"]
     assert_array_equal(csdm_data.dependent_variables[0].components[0], adata1)
@@ -1195,10 +1197,10 @@ def test_csdm_2d():
         j = 1 - i
         assert csdm_data.dimensions[j].count == ubdic2[i]["size"]
         assert csdm_data.dimensions[j].increment.value == 1 / ubdic2[i]["sw"]
-        assert (
-            csdm_data.dimensions[j].reciprocal.coordinates_offset.value
-            == ubdic2[i]["car"]
-        )
+        assert str(csdm_data.dimensions[j].increment.unit) == 's'
+        coordinates_offset = csdm_data.dimensions[j].reciprocal.coordinates_offset
+        assert coordinates_offset.value == ubdic2[i]["car"]
+        assert str(coordinates_offset.unit) == 'Hz'
         assert (
             csdm_data.dimensions[j].reciprocal.origin_offset.value == ubdic2[i]["obs"]
         )
@@ -1217,10 +1219,10 @@ def test_csdm_2d():
         j = 1 - i
         assert csdm_data.dimensions[j].count == uadic2[i]["size"]
         assert csdm_data.dimensions[j].increment.value == 1 / uadic2[i]["sw"]
-        assert (
-            csdm_data.dimensions[j].reciprocal.coordinates_offset.value
-            == uadic2[i]["car"]
-        )
+        assert str(csdm_data.dimensions[j].increment.unit) == 's'
+        coordinates_offset = csdm_data.dimensions[j].reciprocal.coordinates_offset
+        assert coordinates_offset.value == uadic2[i]["car"]
+        assert str(coordinates_offset.unit) == 'Hz'
         assert (
             csdm_data.dimensions[j].reciprocal.origin_offset.value == uadic2[i]["obs"]
         )
@@ -1242,10 +1244,10 @@ def test_csdm_3d():
         i = 2 - j
         assert csdm_data.dimensions[j].count == ubdic3[i]["size"]
         assert csdm_data.dimensions[j].increment.value == 1 / ubdic3[i]["sw"]
-        assert (
-            csdm_data.dimensions[j].reciprocal.coordinates_offset.value
-            == ubdic3[i]["car"]
-        )
+        assert str(csdm_data.dimensions[j].increment.unit) == 's'
+        coordinates_offset = csdm_data.dimensions[j].reciprocal.coordinates_offset
+        assert coordinates_offset.value == ubdic3[i]["car"]
+        assert str(coordinates_offset.unit) == 'Hz'
         assert (
             csdm_data.dimensions[j].reciprocal.origin_offset.value == ubdic3[i]["obs"]
         )
@@ -1273,10 +1275,10 @@ def test_csdm_3d():
         print(csdm_data)
         assert csdm_data.dimensions[j].count == uadic3[i]["size"]
         assert csdm_data.dimensions[j].increment.value == 1 / uadic3[i]["sw"]
-        assert (
-            csdm_data.dimensions[j].reciprocal.coordinates_offset.value
-            == uadic3[i]["car"]
-        )
+        assert str(csdm_data.dimensions[j].increment.unit) == 's'
+        coordinates_offset = csdm_data.dimensions[j].reciprocal.coordinates_offset
+        assert coordinates_offset.value == uadic3[i]["car"]
+        assert str(coordinates_offset.unit) == 'Hz'
         assert (
             csdm_data.dimensions[j].reciprocal.origin_offset.value == uadic3[i]["obs"]
         )

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1164,6 +1164,21 @@ def test_csdm_1d():
     assert csdm_data.dimensions[0].label == ubdic1[0]["label"]
     assert_array_equal(csdm_data.dependent_variables[0].components[0], bdata1)
 
+    # read it as freq dataset
+    csdm_data = bC1.to_csdm(freq_dims=[True])
+    assert len(csdm_data.dimensions) == 1
+    assert len(csdm_data.dependent_variables) == 1
+    assert csdm_data.dimensions[0].count == ubdic1[0]["size"]
+    assert csdm_data.dimensions[0].increment.value == ubdic1[0]["sw"] / ubdic1[0]["size"]
+    assert str(csdm_data.dimensions[0].increment.unit) == 'Hz'
+    coordinates_offset = csdm_data.dimensions[0].coordinates_offset
+    assert csdm_data.dimensions[0].coordinates_offset.value == ubdic1[0]["car"]
+    assert csdm_data.dimensions[0].origin_offset.value == ubdic1[0]["obs"]
+    reciprocal_dim = csdm_data.dimensions[0].reciprocal
+    assert str(reciprocal_dim.quantity_name) == 'time'
+    assert csdm_data.dimensions[0].label == ubdic1[0]["label"]
+    assert_array_equal(csdm_data.dependent_variables[0].components[0], bdata1)
+
     # 1D agilent
     adic1, adata1 = ng.agilent.read(os.path.join(DATA_DIR, "agilent_1d"))
     uadic1 = ng.agilent.guess_udic(adic1, adata1)
@@ -1205,6 +1220,33 @@ def test_csdm_2d():
             csdm_data.dimensions[j].reciprocal.origin_offset.value == ubdic2[i]["obs"]
         )
         assert csdm_data.dimensions[j].label == ubdic2[i]["label"]
+    assert_array_equal(csdm_data.dependent_variables[0].components[0], bdata2)
+
+    # read one dim as freq
+    csdm_data = bC2.to_csdm(freq_dims=[False, True])
+    assert len(csdm_data.dimensions) == 2
+    assert len(csdm_data.dependent_variables) == 1
+
+    # time dim
+    assert csdm_data.dimensions[1].count == ubdic2[0]["size"]
+    assert csdm_data.dimensions[1].increment.value == 1 / ubdic2[0]["sw"]
+    assert str(csdm_data.dimensions[1].increment.unit) == 's'
+    coordinates_offset = csdm_data.dimensions[1].reciprocal.coordinates_offset
+    assert coordinates_offset.value == ubdic2[0]["car"]
+    assert str(coordinates_offset.unit) == 'Hz'
+    assert (
+        csdm_data.dimensions[1].reciprocal.origin_offset.value == ubdic2[0]["obs"]
+    )
+    assert csdm_data.dimensions[1].label == ubdic2[0]["label"]
+
+    # freq dim
+    assert csdm_data.dimensions[0].count == ubdic2[1]["size"]
+    assert csdm_data.dimensions[0].increment.value == ubdic2[1]["sw"] / ubdic2[1]["size"]
+    assert str(csdm_data.dimensions[0].increment.unit) == 'Hz'
+    assert csdm_data.dimensions[0].coordinates_offset.value == ubdic2[1]["car"]
+    assert csdm_data.dimensions[0].reciprocal.quantity_type == 'time'
+    assert csdm_data.dimensions[0].label == ubdic2[1]["label"]
+
     assert_array_equal(csdm_data.dependent_variables[0].components[0], bdata2)
 
     # 2D agilent


### PR DESCRIPTION
### Bug

The current conversion from bruker to csdm format always returns a csdm object with the time domain dimensions. In cases, when the data is read from `pdata` the dimension should be set to frequency domain.

### Fix
Use the udic `freq` or `time` boolean query to check if the data dimension is freq or time domain and then generate the corresponding csdm dimensions.