### PR TITLE
Import for RS2D format

### DIFF
--- a/nmrglue/fileio/__init__.py
+++ b/nmrglue/fileio/__init__.py
@@ -1,15 +1,16 @@
 from . import bruker
 from . import convert
 from . import jcampdx
+from . import jeol
 from . import nmrml
 from . import pipe
 from . import rnmrtk
+from . import rs2d
 from . import simpson
 from . import sparky
+from . import spinsolve
+from . import table
 from . import tecmag
 from . import varian
 # replicate varian namespace in agilent
 from . import varian as agilent
-from . import table
-from . import spinsolve
-from . import jeol

--- a/nmrglue/fileio/rs2d.py
+++ b/nmrglue/fileio/rs2d.py
@@ -1,0 +1,256 @@
+"""
+Functions for reading RS2D data format.
+"""
+
+import os
+from warnings import warn
+
+import numpy as np
+
+from . import fileiobase
+
+__developer_info__ = """
+RS2D file format information
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+NMR spectra in RS2D format are stored in two files:
+- "data.dat"    Binary data in complex64 or float32 (big-endian)
+- "header.xml"  Acquisition/processing parameters in XML format
+
+The complete format specification with test files is distributed
+in nmrglue test data package.
+"""
+
+
+def read(path='.', datafile="data.dat", headerfile="header.xml"):
+    """
+    Reads RS2D files from a directory.
+
+
+    Parameters
+    ----------
+    path : str
+        Directory to read from
+    datafile : str, optional
+        Filename to import spectral data from. Default name is used if not given.
+    headerfile : str, optional
+        Filename for acquisition/processing parameters. Default name is used if not given.
+
+
+    Returns
+    -------
+    dic : dict
+        All parameters read from the header xml file
+    data : ndarray
+        Array of NMR data, either FID or processed. The data will be in shape of
+        [RECEIVER COUNT, DIM4, DIM3, DIM2, DIM1], but if any of these dimensions
+        is 1, it is left out from shape.
+
+    """
+
+    datafilepath = os.path.join(path, datafile)
+    if os.path.isfile(datafilepath) is not True:
+        raise OSError(f"data file {datafilepath} does not exist")
+
+    headerfilepath = os.path.join(path, headerfile)
+    if os.path.isfile(headerfilepath) is not True:
+        raise OSError(f"header file {headerfilepath} does not exist")
+
+    import xmltodict  # delay import so that xmltodict is optional
+    with open(headerfilepath, 'rb') as nmrml_file:
+        rawdict = xmltodict.parse(nmrml_file.read())
+
+    # clean parameter dictionary
+
+    # only read the following relevant parameters from each entry:
+    params_to_read = ("name", "description", "group",
+                      "category", "numberEnum", "value",
+                      "uuid", "uuidBaseFrequency")
+
+    dic = {}
+    for entry in rawdict["header"]["params"]["entry"]:
+        key = entry["key"]
+        dic[key] = {}
+        for param in entry["value"]:
+            if param not in params_to_read:
+                continue
+            if param in dic[key]:
+                # encountering list (multiple same param names)
+                if not isinstance(dic[key][param], list):
+                    # turn this param to list
+                    dic[key][param] = [dic[key][param]]
+                dic[key][param].append(entry["value"][param])
+            # first or singular value
+            dic[key][param] = entry["value"][param]
+
+    # find dimensions
+    try:
+        receiver_count = int(dic['RECEIVER_COUNT']["value"])
+        dim1d = int(dic['MATRIX_DIMENSION_1D']["value"])
+        dim2d = int(dic['MATRIX_DIMENSION_2D']["value"])
+        dim3d = int(dic['MATRIX_DIMENSION_3D']["value"])
+        dim4d = int(dic['MATRIX_DIMENSION_4D']["value"])
+    except (KeyError, ValueError) as e:
+        raise ValueError("Cannot find data dimensions from RS2D header") from e
+
+    # make shape
+    shape = [receiver_count, dim4d, dim3d, dim2d, dim1d]
+    shape = [i for i in shape if i > 1]
+
+    # check data type
+    is_real = False  # default = complex64
+    try:
+        datareps = dic["DATA_REPRESENTATION"]["value"]
+        if isinstance(datareps, list):
+            is_real = datareps[0] == "REAL"
+    except KeyError:
+        pass
+
+    # read and reshape data
+    if is_real:
+        data = np.fromfile(datafilepath, dtype=">f4")
+    else:
+        data = np.fromfile(datafilepath, dtype=">c8")
+    data = np.reshape(data, shape)
+
+    return dic, data
+
+
+def guess_udic(dic, data):
+    """
+    Guess parameters of universal dictionary from dic, data pair.
+
+    Parameters
+    ----------
+    dic : dict
+        Clean dictionary of RS2D parameters from rs2d.read().
+    data : ndarray
+        Array of NMR data.
+
+    Returns
+    -------
+    udic : dict
+        Universal dictionary of spectral parameters.
+    """
+
+    uuid_dict = {}
+    for key, entry in dic.items():
+        uuid = entry.get("uuid", None)
+        if uuid:
+            uuid_dict[uuid] = entry
+
+    # create an empty universal dictionary
+    dims = len(data.shape)
+    # shape may have extra dimension from possible multiple receivers.
+    # in that case decrease one dimension from udic.
+    receiver_count = int(dic['RECEIVER_COUNT']["value"])
+    if receiver_count > 1:
+        dims -= 1
+    udic = fileiobase.create_blank_udic(dims)
+
+    # set udic parameters:
+
+    # "size"
+    # note: shape is already in correct order (direct dimension last)
+    i = 0
+    for i in range(dims):
+        # skip receiver count dimension if present
+        dim = data.shape[i+1] if receiver_count > 1 else data.shape[i]
+        udic[i]["size"] = dim
+
+    # "label"
+    for i, key in enumerate(["NUCLEUS_1", "NUCLEUS_2", "NUCLEUS_3", "NUCLEUS_4"]):
+
+        label = None
+        try:
+            label = dic[key]["value"]
+            udic[dims-i-1]["label"] = label
+        except KeyError:
+            pass
+
+    # "obs"
+    for i, key in enumerate(["BASE_FREQ_1", "BASE_FREQ_2", "BASE_FREQ_3", "BASE_FREQ_4"]):
+        obs_freq = None
+        try:
+            obs_freq = float(dic[key]["value"])
+            udic[dims-i-1]["obs"] = obs_freq/1e6
+        except ValueError:
+            warn(f"Cannot parse {key}")
+        except KeyError:
+            pass
+
+    # "sw"
+    for i, key in enumerate(["SPECTRAL_WIDTH", "SPECTRAL_WIDTH_2D",
+                             "SPECTRAL_WIDTH_3D", "SPECTRAL_WIDTH_4D"]):
+        sw = None
+        try:
+            sw = float(dic[key]["value"])
+            unitname = dic[key].get("numberEnum", None)
+            # sw needs conversion to Hz if stored in ppm:
+            if unitname == "FrequencyShift":
+                # conversion frequency may be user defined. find
+                # correct one by given uuid:
+                try:
+                    uuid_basefreq = dic[key]["uuidBaseFrequency"]
+                    freq_entry = uuid_dict[uuid_basefreq]
+                    basefreq = float(freq_entry["value"])
+                    sw = sw * (basefreq / 1e6)
+                except (KeyError, ValueError):
+                    warn("Cannot set sw: ppm to Hz conversion failed")
+                    sw = None
+            if sw:
+                udic[dims-i-1]["sw"] = sw
+        except ValueError:
+            warn(f"Cannot parse {key}")
+        except KeyError:
+            pass
+
+    # "car"
+    # most conveniently found by calculating
+    # TRANSMIT_FREQ - BASE_FREQ, which are already in Hz
+    for i in range(dims):
+        car = None
+        tag_basefreq = "BASE_FREQ_"+str(i+1)
+        tag_transmitfreq = "TRANSMIT_FREQ_"+str(i+1)
+        try:
+            basefreqhz = float(dic[tag_basefreq]["value"])
+            transmitfreqhz = float(dic[tag_transmitfreq]["value"])
+            car = transmitfreqhz - basefreqhz
+            udic[dims-i-1]["car"] = car
+        except ValueError:
+            warn(f"Cannot parse {tag_basefreq} or {tag_transmitfreq}")
+        except KeyError:
+            pass
+
+    # "time" and "freq"
+
+    # default is FID i.e. time domain:
+    for i in range(dims):
+        udic[i]["freq"] = False
+        udic[i]["time"] = True
+
+    # if STATE is populated, dimensions with value 1 are in frequency domain:
+    try:
+        states = dic["STATE"]["value"]
+        if isinstance(states, list):
+            for i, state in enumerate(states):
+                is_processed = int(state) == 1
+                udic[dims-i-1]["freq"] = is_processed
+                udic[dims-i-1]["time"] = not is_processed
+    except KeyError:
+        pass
+
+    # "complex"
+
+    # default representation is complex values.
+    # if DATA_REPRESENTATION is populated, dimensions with value "REAL"
+    # are represented in real values:
+    try:
+        datareps = dic["DATA_REPRESENTATION"]["value"]
+        if isinstance(datareps, list):
+            for i, datarep in enumerate(datareps):
+                is_real = datarep == "REAL"
+                udic[dims-i-1]["complex"] = not is_real
+    except KeyError:
+        pass
+
+    return udic

--- a/tests/test_rs2d.py
+++ b/tests/test_rs2d.py
@@ -1,0 +1,110 @@
+""" Tests for the fileio.rs2d submodule """
+
+import os
+import numpy as np
+import nmrglue as ng
+from setup import DATA_DIR
+
+
+def test_rs2d():
+    '''RS2D read: format testset. Expects to find the provided test cases under 
+    data/rs2d/Installer_data'''
+
+    # case tuple is:
+    #  0       1      2       3,          4            5        6
+    # (folder, shape, is_fid, is_complex, basefreqMHz, sweepHz, offsetHz,
+    #  7        8        9
+    #  nucleus, solvent, temperature)
+
+    # tested values are collected manually from header.xml files
+
+    cases = []
+
+    # -------------------------------------------------------------------------
+
+    # 1D 1H (FID)
+    bf_hz = 4.001293456641604E8  # BASE_FREQ
+    bf_mhz = bf_hz/1e6
+    # OBSERVED_FREQUENCY (for sw conversion!)
+    tf_hz = 4.0013094618154305E8
+    tf_mhz = tf_hz/1e6
+    car = tf_hz - bf_hz
+    cases.append(("1", (16384,), True, True, (bf_mhz,),
+                 (10.000439579964194 * tf_mhz,), (car,), ("1H",), "CDCl3", 298))
+
+    # 1D 1H (PROCESSED)
+    cases.append(("1/Proc/0", (32768,), False, True, (bf_mhz,),
+                 (10.000439579964194 * tf_mhz,), (car,), ("1H",), "CDCl3", 298))
+
+    # -------------------------------------------------------------------------
+
+    # 1D 13C (FID)
+    bf_hz = 1.006126140544557E8
+    bf_mhz = bf_hz/1e6
+    tf_hz = 1.006216691897206E8  # OBSERVED_FREQUENCY (for sw conversion!)
+    tf_mhz = tf_hz/1e6
+    car = tf_hz - bf_hz
+    cases.append(("2", (32768,), True, True, (bf_mhz,),
+                 (200.00598044404157 * tf_mhz,), (car,), ("13C",), "Benzene", 298))
+
+    # 1D 13C (PROCESSED)
+    cases.append(("2/Proc/0", (65536,), False, True, (bf_mhz,),
+                  (200.00598044404157 * tf_mhz,), (car,), ("13C",), "Benzene", 298))
+
+    # -------------------------------------------------------------------------
+
+    # 2D HSQC (FID)
+    bf_hz_1 = 4.001293856773854E8
+    bf_mhz_1 = bf_hz_1/1e6
+    bf_hz_2 = 1.006126140544557E8
+    bf_mhz_2 = bf_hz_2/1e6
+
+    tf_hz_1 = 4.0013138632431376E8  # OBSERVED_FREQUENCY (for sw conversion!)
+    tf_mhz_1 = tf_hz_1/1e6
+    tf_hz_2 = 1.0062066306358005E8  # TRANSMIT_FREQ_2 (for sw conversion!)
+    tf_mhz_2 = tf_hz_2/1e6
+    car_1 = tf_hz_1 - bf_hz_1
+    car_2 = tf_hz_2 - bf_hz_2
+    cases.append(("17", (256, 1024), True, True, (bf_mhz_2, bf_mhz_1),
+                  (199.9544840071294 * tf_mhz_2, 11.993142972152109 * tf_mhz_1),
+                 (car_2, car_1), ("13C", "1H"), "Benzene", 298))
+
+    # 2D HSQC (PROCESSED)
+    cases.append(("17/Proc/0", (256, 2048), False, True, (bf_mhz_2, bf_mhz_1),
+                  (199.9544840071294 * tf_mhz_2, 11.993142972152109 * tf_mhz_1),
+                 (car_2, car_1), ("13C", "1H"), "Benzene", 298))
+
+    # -------------------------------------------------------------------------
+
+    epsilon = 1e-9
+
+    for case in cases:
+
+        folder = case[0]
+        print("RS2D case:", folder)
+
+        # read
+        casepath = os.path.join(DATA_DIR, "rs2d", "Installer_Data", folder)
+        dic, data = ng.rs2d.read(casepath)
+
+        # check data:
+        assert data.shape == case[1]
+
+        # check udic:
+        udic = ng.rs2d.guess_udic(dic, data)
+        for dim in range(len(data.shape)):
+            assert udic[dim]["time"] is case[2]
+            assert udic[dim]["freq"] is not case[2]
+            assert np.abs(udic[dim]["obs"] - case[4][dim]) < epsilon
+            assert np.abs(udic[dim]["sw"] - case[5][dim]) < epsilon
+            assert np.abs(udic[dim]["car"] - case[6][dim]) < epsilon
+            assert udic[dim]["size"] == case[1][dim]
+            assert udic[dim]["label"] == case[7][dim]
+
+        # data type (complex/real) tested only for the first dimension
+        assert udic[len(data.shape)-1]["complex"] is case[3]
+
+        # check some rs2d dict values:
+        assert dic["SOLVENT"]["value"] == case[8]
+        temperature = float(dic["SAMPLE_TEMPERATURE"]["value"])
+        assert np.abs(temperature - case[9]) < epsilon


### PR DESCRIPTION
This PR adds the import module for the RS2D (https://rs2d.com/) / QUAD (https://quadsystems.tech/) format including universal dictionary functionality (guess_udic()).

Tests covering basic 1D and 2D experiments are included, and CC licensed test data is kindly provided by QUAD Systems. The test data set is free to be added to the nmrglue test data package. It is temporarily available at 
https://drive.google.com/file/d/1FXTuLV4FDK72KEC31zLFmkHDeNPEuDTo/view

, please let me know once you have downloaded it.

Special acknowledgements for Thomas Paris and Gaëtan Assemat from QUAD Systems for helping me to put this together!