### PR TITLE
Fix deprecated scipy calls

### DIFF
--- a/nmrglue/process/proc_base.py
+++ b/nmrglue/process/proc_base.py
@@ -2644,7 +2644,7 @@ def zd_gaussian(data, wide=1.0, x0=0.0, slope=1.0, g=1):
 
     """
     tln2 = np.sqrt(2 * np.log(2))
-    window = 1 - scipy.signal.gaussian(2 * wide + 1, g / tln2)
+    window = 1 - scipy.signal.windows.gaussian(2 * wide + 1, g / tln2)
     return zd(data, window, x0=x0, slope=slope)
 
 

--- a/nmrglue/process/proc_bl.py
+++ b/nmrglue/process/proc_bl.py
@@ -206,7 +206,7 @@ def calc_bl_med(x, mw, sf, sigma):
     # described algorithm but is MUCH faster
 
     # convolve with a gaussian
-    g = scipy.signal.gaussian(sf, sigma)
+    g = scipy.signal.windows.gaussian(sf, sigma)
     g = g / g.sum()
     return scipy.signal.convolve(m, g, mode='same')
 
@@ -360,7 +360,7 @@ def sol_gaussian(data, w=16, mode='same'):
     """
     Solvent filter with square gaussian filter. See :py:func:`sol_general`.
     """
-    filter = scipy.signal.gaussian(w, w / 2.)
+    filter = scipy.signal.windows.gaussian(w, w / 2.)
     return sol_general(data, filter, w=w, mode=mode)
 
 


### PR DESCRIPTION
`scipy.signal.gaussian` was deprecated in SciPy 1.1 after being moved to `scipy.signal.windows.gaussian`.