### PR TITLE
bugfix: Fix zero-shift bug in proc_base.ls and proc_base.rs

### DIFF
--- a/nmrglue/process/proc_base.py
+++ b/nmrglue/process/proc_base.py
@@ -324,7 +324,7 @@ def tri(data, loc="auto", lHi=0.0, rHi=0.0, inv=False, rev=False):
 ###################
 
 
-def rs(data, pts=0.0):
+def rs(data, pts=0):
     """
     Right shift and zero fill.
 
@@ -345,12 +345,14 @@ def rs(data, pts=0.0):
     roll : shift without zero filling.
 
     """
+    if int(pts) == 0:
+        return data
     data = np.roll(data, int(pts), axis=-1)
     data[..., :int(pts)] = 0
     return data
 
 
-def ls(data, pts=0.0):
+def ls(data, pts=0):
     """
     Left shift and fill with zero
 
@@ -371,6 +373,8 @@ def ls(data, pts=0.0):
     roll : shift without zero filling.
 
     """
+    if int(pts) == 0:
+        return data
     data = np.roll(data, -int(pts), axis=-1)
     data[..., -int(pts):] = 0
     return data


### PR DESCRIPTION
Fixes a bug in the `ls` (left shift) and `rs` (right shift) functions in `nmrglue.process.proc_base`.

Problem:
When called with the default argument `pts=0`, both functions overwrite the entire `data` array with zeros, instead of leaving the data unchanged. The issue arises because the line "`data[..., :int(pts)] = 0`" zeroes out the entire data when `pts` is 0.

Fix:
- Added a simple guard clause to both `ls` and `rs`.
```
if int(pts) == 0:
    return data
```
- Changed the default parameter from `pts=0.0` to `pts=0` for clarity, especially with the docstring describing `pts` as int.