### PR TITLE
bugfix: Fix zero-shift bug in `proc_base.ls`

### DIFF
--- a/nmrglue/process/proc_base.py
+++ b/nmrglue/process/proc_base.py
@@ -324,7 +324,7 @@ def tri(data, loc="auto", lHi=0.0, rHi=0.0, inv=False, rev=False):
 ###################
 
 
-def rs(data, pts=0.0):
+def rs(data, pts=0):
     """
     Right shift and zero fill.
 
@@ -345,12 +345,13 @@ def rs(data, pts=0.0):
     roll : shift without zero filling.
 
     """
+
     data = np.roll(data, int(pts), axis=-1)
     data[..., :int(pts)] = 0
     return data
 
 
-def ls(data, pts=0.0):
+def ls(data, pts=0):
     """
     Left shift and fill with zero
 
@@ -371,12 +372,14 @@ def ls(data, pts=0.0):
     roll : shift without zero filling.
 
     """
+    if int(pts) == 0:
+        return data
     data = np.roll(data, -int(pts), axis=-1)
     data[..., -int(pts):] = 0
     return data
 
 
-def cs(data, pts=0.0, neg=False):
+def cs(data, pts=0, neg=False):
     """
     Circular shift
 
@@ -399,7 +402,7 @@ def cs(data, pts=0.0, neg=False):
     return roll(data, pts, neg)
 
 
-def roll(data, pts=0.0, neg=False):
+def roll(data, pts=0, neg=False):
     """
     Roll axis
 


### PR DESCRIPTION
Fixes a bug in the left shift function `nmrglue.process.proc_base.ls()`.

Problem:
When `proc_base.ls()` is called with the default argument `pts=0`, it overwrites the entire `data` array with zeros, instead of leaving the data unchanged. The issue arises because the line "`data[..., -int(pts):] = 0`" zeroes out the entire data when `pts` is 0.

Fix:
- Added a simple guard clause to `ls`:
```
if int(pts) == 0:
    return data
```
- Changed the default parameter from `pts=0.0` to `pts=0` in a few functions for clarity, especially since their docstrings describe `pts` as int.

Note: My previous pull request incorrectly claimed this bug existed for both the left shift `ls()` and right shift `rs()` functions. I have closed and replaced that old pull request with this one, because this bug only exists for the left shift function.