### PR TITLE
Fix: Handle UTF-8 BOM in JCAMP-DX files

### DIFF
--- a/nmrglue/fileio/jcampdx.py
+++ b/nmrglue/fileio/jcampdx.py
@@ -51,7 +51,7 @@ def _parsejcampdx(filename):
     # when encountering ##END, push the ready dict to another list
     readyblocklist = []
 
-    filein = open(filename, 'r', encoding="utf-8", errors="replace")
+    filein = open(filename, 'r', encoding="utf-8-sig", errors="replace")
 
     currentkey = None
     currentvaluestrings = []


### PR DESCRIPTION
Problem:
Some JCAMP-DX files contain a UTF-8 Byte Order Mark (BOM: \ufeff) at the beginning of the file, which causes parsing failures when the first line doesn't start with ##.

Solution:
Changed the file encoding from utf-8 to utf-8-sig when opening JCAMP-DX files. Python's built-in utf-8-sig codec automatically detects and strips the BOM if present, while remaining fully compatible with files without a BOM (backward compatibility) so that file parsing more robust.

See: [python3 library codecs utf-8-sig](https://docs.python.org/3/library/codecs.html#module-encodings.utf_8_sig)