### PR TITLE
Add optional  bounds parameters to autophase

### DIFF
--- a/nmrglue/process/proc_autophase.py
+++ b/nmrglue/process/proc_autophase.py
@@ -13,7 +13,8 @@ import scipy.optimize
 from .proc_base import ps
 
 
-def autops(data, fn, p0=0.0, p1=0.0, return_phases=False, peak_width=100, **kwargs):
+def autops(data, fn, p0=0.0, p1=0.0, return_phases=False, peak_width=100,
+           bounds=None, **kwargs):
     """
     Automatic linear phase correction
 
@@ -29,29 +30,65 @@ def autops(data, fn, p0=0.0, p1=0.0, return_phases=False, peak_width=100, **kwar
     p1 : float
         Initial first order phase in degrees.
     peak_width : int
-        Width of the ROI for peak_minima optimization (number of surrounding indexes)
-    return_phases : Bool
-        returns a list of optimized values of phases [p0, p1] in addition
-        to the phased data
-    kwargs : additional key-word arguments to be passed to the solver
-        The are documented at the following link:
-        https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.fmin.html
-        Some of the more useful ones for this use case:
+        Width of the ROI for peak_minima optimization (number of surrounding
+        indexes). Only used when fn='peak_minima'.
+    return_phases : bool
+        If True, also return the optimised ``[p0, p1]`` list in addition to
+        the phased data.
+    bounds : sequence of two (min, max) pairs or None, optional
+        Bounds on the zero- and first-order phases, respectively, in degrees.
+        For example ``bounds=[(-180, 180), (-1800, 1800)]`` restricts p0 to
+        +-180 and p1 to +-1800 degrees. When *bounds* is provided the
+        optimisation uses :func:`scipy.optimize.minimize` with the Nelder-Mead
+        method (same simplex algorithm as :func:`scipy.optimize.fmin`) so the
+        solver behaviour is equivalent but constrained. When *bounds* is
+        ``None`` (default) the original unconstrained
+        :func:`scipy.optimize.fmin` is used and the function is fully
+        backward-compatible.
 
-        * disp : Bool
-            Turns on or off the printing of convergence messages
-            By default, this is set to True.
-        * ftol : float
-            Absolute error in fn between iterations that is acceptable for
-            convergence. The default is 1e-4.
+        Bounds are useful to find only the zero-order phase (set p1 bounds to
+        ``(0, 0)``), or to prevent the optimiser from wandering into physically
+        unreasonable regions when the spectrum has poor initial phase.
+    kwargs : additional key-word arguments
+        Passed directly to the underlying solver.
+
+        When *bounds* is ``None`` (fmin): see
+        https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.fmin.html
+        Useful options: ``disp`` (bool), ``ftol`` (float).
+
+        When *bounds* is provided (minimize): see
+        https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html
+        The method is fixed to 'Nelder-Mead'; pass e.g.
+        ``options={'xatol': 1e-4}``.
 
     Returns
     -------
     ndata : ndarray
         Phased NMR data.
+    opt : list of float, optional
+        ``[p0, p1]`` optimised phase values in degrees. Only returned when
+        *return_phases* is ``True``.
+
+    Examples
+    --------
+    Unconstrained autophase (original behaviour):
+
+    >>> phased = ng.proc_autophase.autops(data, 'acme')
+
+    Bounded autophase — restrict search to +-180 in p0, +-1800 in p1:
+
+    >>> phased, phases = ng.proc_autophase.autops(
+    ...     data, 'acme', p0=0.0, p1=0.0,
+    ...     bounds=[(-180, 180), (-1800, 1800)],
+    ...     return_phases=True)
+
+    Zero-order only — fix p1 to zero:
+
+    >>> phased = ng.proc_autophase.autops(
+    ...     data, 'acme', bounds=[(-180, 180), (0, 0)])
 
     """
-    arguments = [data,]
+    arguments = [data]
 
     if not callable(fn):
         if fn == 'peak_minima':
@@ -63,11 +100,23 @@ def autops(data, fn, p0=0.0, p1=0.0, return_phases=False, peak_width=100, **kwar
                 'acme': _ps_acme_score,
             }[fn]
         except KeyError:
-            raise KeyError(f'Unable to find algorithm "{fn}". Use "acme", "peak_minima" or pass a custom function.')
+            raise KeyError(
+                f'Unable to find algorithm "{fn}". '
+                'Use "acme", "peak_minima" or pass a custom function.'
+            )
 
     opt = [p0, p1]
 
-    opt = scipy.optimize.fmin(fn, x0=opt, args=tuple(arguments), **kwargs)
+    if bounds is not None:
+        result = scipy.optimize.minimize(
+            fn, x0=opt, args=tuple(arguments),
+            method='Nelder-Mead',
+            bounds=bounds,
+            **kwargs,
+        )
+        opt = result.x
+    else:
+        opt = scipy.optimize.fmin(fn, x0=opt, args=tuple(arguments), **kwargs)
 
     phasedspc = ps(data, p0=opt[0], p1=opt[1])
 

--- a/tests/test_autophase.py
+++ b/tests/test_autophase.py
@@ -1,0 +1,248 @@
+"""
+tests/test_autophase.py — Tests for nmrglue.process.proc_autophase
+
+Covers autops() with and without bounds, both built-in scoring functions,
+callable scoring functions, return_phases flag, and error handling.
+
+The bounded path uses scipy.optimize.minimize (Nelder-Mead); the unbounded
+path uses scipy.optimize.fmin. Both are exercised here.
+"""
+import numpy as np
+from numpy.testing import assert_allclose
+import pytest
+
+import nmrglue as ng
+from nmrglue.process.proc_autophase import (
+    autops,
+    _ps_acme_score,
+    _ps_peak_minima_score,
+)
+from nmrglue.process.proc_base import ps
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+def _lorentzian_spectrum(n=512, sw=10000.0, f0=1000.0, t2=0.1, p0=0.0, p1=0.0):
+    """Return a phase-shifted Lorentzian spectrum (complex ndarray).
+
+    Parameters
+    ----------
+    n   : int   — number of points
+    sw  : float — spectral width (Hz)
+    f0  : float — peak frequency (Hz)
+    t2  : float — transverse relaxation time (s)
+    p0  : float — zero-order phase error (degrees)
+    p1  : float — first-order phase error (degrees)
+    """
+    t = np.arange(n) / sw
+    fid = np.exp(1j * 2 * np.pi * f0 * t) * np.exp(-t / t2)
+    spec = np.fft.fftshift(np.fft.fft(fid))
+    return ps(spec, p0=p0, p1=p1)
+
+
+# =============================================================================
+# Backward-compatibility — unbounded (original fmin path)
+# =============================================================================
+
+def test_autops_acme_returns_ndarray():
+    """autops with 'acme' returns an ndarray of the same shape."""
+    data = _lorentzian_spectrum(p0=30.0)
+    result = autops(data, 'acme', disp=False)
+    assert isinstance(result, np.ndarray)
+    assert result.shape == data.shape
+
+
+def test_autops_peak_minima_returns_ndarray():
+    """autops with 'peak_minima' returns an ndarray of the same shape."""
+    data = _lorentzian_spectrum(p0=30.0)
+    result = autops(data, 'peak_minima', disp=False)
+    assert isinstance(result, np.ndarray)
+    assert result.shape == data.shape
+
+
+def test_autops_return_phases_unbounded():
+    """return_phases=True returns (ndarray, array-like) with two elements."""
+    data = _lorentzian_spectrum(p0=45.0)
+    result = autops(data, 'acme', return_phases=True, disp=False)
+    assert isinstance(result, tuple) and len(result) == 2
+    phased, opt = result
+    assert isinstance(phased, np.ndarray)
+    assert len(opt) == 2
+
+
+def test_autops_callable_fn_unbounded():
+    """A callable scoring function is accepted in place of a string alias."""
+    data = _lorentzian_spectrum(p0=20.0)
+    result = autops(data, _ps_acme_score, disp=False)
+    assert isinstance(result, np.ndarray)
+
+
+def test_autops_unknown_fn_raises():
+    """An unrecognised string fn raises KeyError with a helpful message."""
+    data = _lorentzian_spectrum()
+    with pytest.raises(KeyError, match='Unable to find algorithm'):
+        autops(data, 'not_a_real_algorithm')
+
+
+def test_autops_acme_reduces_phase_error():
+    """autops 'acme' reduces a known phase error towards zero."""
+    p0_true = 60.0
+    data = _lorentzian_spectrum(p0=p0_true)
+    phased, opt = autops(data, 'acme', return_phases=True, disp=False)
+    # After correction the residual phase should be much smaller than the
+    # original error (we don't require exact recovery — ACME is heuristic).
+    assert abs(opt[0]) < abs(p0_true)
+
+
+# =============================================================================
+# Bounded path — scipy.optimize.minimize(Nelder-Mead)
+# =============================================================================
+
+def test_autops_bounded_returns_ndarray():
+    """autops with bounds= returns an ndarray of the same shape."""
+    data = _lorentzian_spectrum(p0=30.0)
+    result = autops(data, 'acme', bounds=[(-180, 180), (-1800, 1800)])
+    assert isinstance(result, np.ndarray)
+    assert result.shape == data.shape
+
+
+def test_autops_bounded_return_phases():
+    """return_phases=True with bounds returns (ndarray, array-like)."""
+    data = _lorentzian_spectrum(p0=45.0)
+    phased, opt = autops(data, 'acme',
+                         bounds=[(-180, 180), (-1800, 1800)],
+                         return_phases=True)
+    assert isinstance(phased, np.ndarray)
+    assert len(opt) == 2
+
+
+def test_autops_p1_fixed_to_zero():
+    """Bounds (0, 0) on p1 keep the first-order phase exactly zero."""
+    data = _lorentzian_spectrum(p0=50.0, p1=0.0)
+    _, opt = autops(data, 'acme',
+                    bounds=[(-180, 180), (0, 0)],
+                    return_phases=True)
+    assert abs(opt[1]) < 1e-6, f"p1 should be 0.0, got {opt[1]}"
+
+
+def test_autops_p0_fixed_to_zero():
+    """Bounds (0, 0) on p0 keep the zero-order phase exactly zero."""
+    data = _lorentzian_spectrum(p0=0.0, p1=200.0)
+    _, opt = autops(data, 'acme',
+                    bounds=[(0, 0), (-1800, 1800)],
+                    return_phases=True)
+    assert abs(opt[0]) < 1e-6, f"p0 should be 0.0, got {opt[0]}"
+
+
+def test_autops_bounded_respects_p0_range():
+    """Optimised p0 stays within the specified bounds."""
+    data = _lorentzian_spectrum(p0=30.0)
+    b0 = (-90, 90)
+    _, opt = autops(data, 'acme',
+                    bounds=[b0, (-1800, 1800)],
+                    return_phases=True)
+    assert b0[0] <= opt[0] <= b0[1], f"p0={opt[0]} outside {b0}"
+
+
+def test_autops_bounded_respects_p1_range():
+    """Optimised p1 stays within the specified bounds."""
+    data = _lorentzian_spectrum(p0=0.0, p1=300.0)
+    b1 = (-500, 500)
+    _, opt = autops(data, 'acme',
+                    bounds=[(-180, 180), b1],
+                    return_phases=True)
+    assert b1[0] <= opt[1] <= b1[1], f"p1={opt[1]} outside {b1}"
+
+
+def test_autops_bounded_acme_reduces_phase_error():
+    """Bounded autops 'acme' reduces a known phase error towards zero."""
+    p0_true = 60.0
+    data = _lorentzian_spectrum(p0=p0_true)
+    _, opt = autops(data, 'acme',
+                    bounds=[(-180, 180), (-1800, 1800)],
+                    return_phases=True)
+    assert abs(opt[0]) < abs(p0_true)
+
+
+def test_autops_bounded_peak_minima():
+    """Bounded autops works with 'peak_minima' scoring function."""
+    data = _lorentzian_spectrum(p0=40.0)
+    result = autops(data, 'peak_minima',
+                    bounds=[(-180, 180), (-1800, 1800)])
+    assert isinstance(result, np.ndarray)
+    assert result.shape == data.shape
+
+
+def test_autops_bounded_callable_fn():
+    """Bounded autops accepts a callable scoring function."""
+    data = _lorentzian_spectrum(p0=25.0)
+    phased, opt = autops(data, _ps_acme_score,
+                         bounds=[(-180, 180), (-1800, 1800)],
+                         return_phases=True)
+    assert isinstance(phased, np.ndarray)
+    assert len(opt) == 2
+
+
+def test_autops_bounded_unknown_fn_raises():
+    """An unrecognised string fn raises KeyError even when bounds are set."""
+    data = _lorentzian_spectrum()
+    with pytest.raises(KeyError, match='Unable to find algorithm'):
+        autops(data, 'not_a_real_algorithm',
+               bounds=[(-180, 180), (-1800, 1800)])
+
+
+def test_autops_bounded_kwargs_passed_to_minimize():
+    """Extra kwargs are forwarded to scipy.optimize.minimize."""
+    data = _lorentzian_spectrum(p0=30.0)
+    # options= is a minimize-specific kwarg; should not raise
+    phased, opt = autops(data, 'acme',
+                         bounds=[(-180, 180), (-1800, 1800)],
+                         return_phases=True,
+                         options={'xatol': 1e-2, 'fatol': 1e-2, 'disp': False})
+    assert isinstance(phased, np.ndarray)
+
+
+def test_autops_bounded_vs_unbounded_agreement():
+    """Bounded and unbounded results are consistent on a well-conditioned spectrum."""
+    data = _lorentzian_spectrum(p0=30.0, p1=0.0)
+    _, opt_ub = autops(data, 'acme', return_phases=True, disp=False)
+    _, opt_b  = autops(data, 'acme',
+                       bounds=[(-180, 180), (-1800, 1800)],
+                       return_phases=True)
+    # Both should find similar p0 (within solver tolerance + ACME heuristic noise)
+    assert abs(opt_ub[0] - opt_b[0]) < 10.0, (
+        f"Unbounded p0={opt_ub[0]:.2f} and bounded p0={opt_b[0]:.2f} disagree")
+
+
+# =============================================================================
+# Score function unit tests
+# =============================================================================
+
+def test_acme_score_returns_scalar():
+    """_ps_acme_score returns a finite scalar."""
+    data = _lorentzian_spectrum()
+    score = _ps_acme_score((0.0, 0.0), data)
+    assert np.isfinite(score)
+    assert np.isscalar(score) or score.ndim == 0
+
+
+def test_acme_score_lower_for_phased():
+    """_ps_acme_score is lower for correctly phased than misphased data."""
+    data = _lorentzian_spectrum()
+    score_good = _ps_acme_score((0.0, 0.0), data)
+    score_bad  = _ps_acme_score((90.0, 0.0), data)
+    assert score_good < score_bad
+
+
+def test_peak_minima_score_returns_scalar():
+    """_ps_peak_minima_score returns a finite scalar."""
+    data = _lorentzian_spectrum()
+    score = _ps_peak_minima_score((0.0, 0.0), data, peak_width=50)
+    assert np.isfinite(score)
+
+
+if __name__ == '__main__':
+    import pytest as _pytest
+    _pytest.main([__file__, '-v'])


### PR DESCRIPTION
# Add `bounds` parameter to `autops` for constrained phase optimisation

## Summary

Extends `autops` with an optional `bounds` parameter that constrains the
zero- and first-order phase search range. When `bounds` is `None` (default)
the function is fully backward-compatible with the existing `fmin`-based
behaviour. When bounds are provided, `scipy.optimize.minimize` with the
Nelder-Mead method is used — the same simplex algorithm as `fmin`, but
constrained.

Backward-compatible, no existing interface changed.

## Motivation

The unconstrained optimiser can wander into physically unreasonable phase
regions when or returning huge multiple:

- The spectrum has low SNR or overlapping peaks.
- Only a zero-order correction is needed (first-order should be fixed to zero).
- Hardware constraints limit the plausible phase range (e.g. a known
  transmitter phase offset restricts p0 to a narrow window).

A bounded search prevents these failure modes without changing the algorithm
or the default behavior.


## Changes

**`nmrglue/process/proc_autophase.py`**

- `autops` signature: `bounds=None` added after `peak_width`.
- When `bounds is None`: existing `scipy.optimize.fmin` path, unchanged.
- When `bounds` is provided: `scipy.optimize.minimize(..., method='Nelder-Mead', bounds=bounds)` used instead.
- `**kwargs` are forwarded to the active solver in both paths.
- Docstring updated with parameter description, solver notes, and usage examples.

No other functions were modified.

**`tests/test_autophase.py`** (new file)

21 tests covering:
- Unbounded path: `acme`, `peak_minima`, `return_phases`, callable fn, bad fn name, phase error reduction.
- Bounded path: same coverage plus p0/p1 fixed to zero, bounds respected for p0 and p1 ranges, `options` kwarg forwarded to `minimize`, bounded vs unbounded agreement on a well-conditioned spectrum.
- Score function unit tests: `_ps_acme_score` and `_ps_peak_minima_score`.

---

## Usage

```python
# Original — unchanged
phased = ng.proc_autophase.autops(data, 'acme')

# Bounded search — restrict to physically reasonable range
phased, phases = ng.proc_autophase.autops(
    data, 'acme',
    p0=0.0, p1=0.0,
    bounds=[(-180, 180), (-1800, 1800)],
    return_phases=True,
)

# Zero-order correction only — fix p1 to zero
phased = ng.proc_autophase.autops(
    data, 'acme',
    bounds=[(-180, 180), (0, 0)],
)

# Pass solver options to scipy.optimize.minimize
phased = ng.proc_autophase.autops(
    data, 'acme',
    bounds=[(-180, 180), (-1800, 1800)],
    options={'xatol': 1e-3, 'fatol': 1e-3},
)
```

---

## Relation to #48

PR #48 proposed adding `order` and `gamma` parameters to `_ps_acme_score`
to make the penalty scaling tunable. That PR was never merged and the
hardcoded `gamma=1000` remains in the current `_ps_acme_score`.

The present PR deliberately does **not** touch `_ps_acme_score` — that is a
separate concern that deserves its own PR. However, the two changes are
compatible: if `_ps_acme_score` is later extended to accept `gamma` as a
positional argument (as proposed in #48), extra parameters can be forwarded
through the existing `args=tuple(arguments)` mechanism in both the `fmin`
and `minimize` paths without any further changes to `autops`.



