### PR TITLE
feat(jcampdx): add `read_err` parameter for configurable decode error handling in JCAMP-DX reader

### DIFF
--- a/nmrglue/fileio/jcampdx.py
+++ b/nmrglue/fileio/jcampdx.py
@@ -37,7 +37,7 @@ def _getkey(keystr):
             .replace("-", "").replace("_", "").replace("/", ""))
 
 
-def _parsejcampdx(filename):
+def _parsejcampdx(filename, read_err=None):
     '''
     Actual JCAMP-DX reading. Returns a list of data sections i.e. "blocks",
     each of them being a dictionary of JCAMP-DX tags
@@ -51,7 +51,8 @@ def _parsejcampdx(filename):
     # when encountering ##END, push the ready dict to another list
     readyblocklist = []
 
-    filein = open(filename, 'r', encoding="utf-8-sig", errors="replace")
+    errors = "replace" if read_err is None else read_err
+    filein = open(filename, 'r', encoding="utf-8-sig", errors=errors)
 
     currentkey = None
     currentvaluestrings = []
@@ -148,7 +149,7 @@ def _parsejcampdx(filename):
     return readyblocklist
 
 
-def _readrawdic(filename):
+def _readrawdic(filename, read_err=None):
     '''
     Reads entire JCAMP-DX file to dictionary, from which actual
     data is parsed later. Return value is a dictionary of different
@@ -157,7 +158,7 @@ def _readrawdic(filename):
     '''
 
     # parse file to list of "blocks" i.e. separate data sections
-    blocklist = _parsejcampdx(filename)
+    blocklist = _parsejcampdx(filename, read_err)
 
     # clean whitespace from entries, and remove empty entries
     cleandiclist = []
@@ -575,7 +576,7 @@ def getdataarray(dic):
     return data
 
 
-def read(filename):
+def read(filename, read_err=None):
     """
     Read JCAMP-DX file
 
@@ -583,6 +584,11 @@ def read(filename):
     ----------
     filename : str
         File to read from.
+    read_err : str, optional
+        Error handling for character decoding, passed to open() as the
+        ``errors`` parameter. Valid values include 'strict', 'ignore',
+        'replace', 'backslashreplace', etc. Defaults to None which uses
+        'replace'.
 
     Returns
     -------
@@ -601,7 +607,7 @@ def read(filename):
     # first read everything (including data array) to "raw" dictionary,
     # in which data values are read as raw strings including whitespace
     # and newlines
-    dic = _readrawdic(filename)
+    dic = _readrawdic(filename, read_err)
 
     # select the relevant data section.
     # first try to parse NMRSPECTRUM sections in order,

--- a/tests/test_jcampdx.py
+++ b/tests/test_jcampdx.py
@@ -1,6 +1,7 @@
 """ Tests for the fileio.jcampdx submodule """
 
 import os
+import tempfile
 import numpy as np
 import nmrglue as ng
 from setup import DATA_DIR
@@ -222,3 +223,37 @@ def test_jcampdx_dicstructure2():
     # check data
     assert len(data2) == 8
     assert data2[-1] == 1.0
+
+
+def test_jcampdx_read_err_param():
+    # Test reading with read_err custom parameters
+    content_bad = (
+        "##TITLE=Test Bad UTF8\n"
+        "##JCAMPDX=5.0\n"
+        "##DATATYPE=NMR SPECTRUM\n"
+        "##$BAD=\xff\xfe\xfd\n"
+        "##END=\n"
+    )
+
+    import pytest
+
+    fd, path = tempfile.mkstemp()
+    try:
+        with os.fdopen(fd, 'wb') as f:
+            f.write(content_bad.encode('latin1'))
+
+        # Test default (read_err=None, fallback to replace) does not crash
+        dic, data = ng.jcampdx.read(path)
+        subdic = dic["_datatype_NMRSPECTRUM"][0]
+        assert "\ufffd" in subdic["$BAD"][0]
+
+        # Test read_err='ignore' does not crash and drops the bad characters
+        dic2, data2 = ng.jcampdx.read(path, read_err='ignore')
+        subdic2 = dic2["_datatype_NMRSPECTRUM"][0]
+        assert "$BAD" not in subdic2
+
+        # Test read_err='strict' raises UnicodeDecodeError
+        with pytest.raises(UnicodeDecodeError):
+            ng.jcampdx.read(path, read_err='strict')
+    finally:
+        os.remove(path)


### PR DESCRIPTION
### Summary

Exposes a `read_err` parameter on the public `read()` function so callers can control how character decoding errors are handled when reading JCAMP-DX files.

### Changes

- Add `read_err` parameter to `read()`, `_readrawdic()`, and `_parsejcampdx()`.
- The parameter is passed directly as the `errors` argument to `open()`.
- Defaults to `None`, which preserves the current behavior of using `'replace'`.
- Valid values include `'strict'`, `'ignore'`, `'replace'`, `'backslashreplace'`, etc. (any value accepted by Python's `open()`).
- Add docstring documenting the parameter and valid values.

### Motivation

Some workflows need strict control over how encoding errors are handled. For example:
- Data validation pipelines may want `'strict'` to detect corrupted files.
- Automated processing may want `'ignore'` to silently drop invalid bytes.
- The default `'replace'` is appropriate for interactive use where U+FFFD substitution is acceptable.

### Testing

- New test `test_jcampdx_read_err_param` verifies:
  - Default (`None` → `'replace'`): invalid bytes replaced with U+FFFD.
  - `'ignore'`: invalid bytes silently dropped.
  - `'strict'`: raises `UnicodeDecodeError`.
- All existing tests continue to pass.