### PR TITLE
feat(jcampdx): read nD NMR SPECTRUM sections and extract all NTUPLES pages

### DIFF
--- a/nmrglue/fileio/jcampdx.py
+++ b/nmrglue/fileio/jcampdx.py
@@ -495,10 +495,18 @@ def find_yfactors(dic):
     return (factor_r, factor_i)
 
 
-def getdataarray(dic):
+def getdataarray(dic, show_all_data=False):
     '''
     Main function for data array parsing, input is the
     raw dictionary from _readrawdic
+
+    Parameters
+    ----------
+    dic : dict
+        Raw dictionary from _readrawdic.
+    show_all_data : bool
+        If True and data is NTUPLES, return all data arrays as a dict
+        with keys 'real' and 'imaginary', each containing a list of arrays.
     '''
 
     data = None
@@ -525,19 +533,22 @@ def getdataarray(dic):
                     idatalist.append(data)
                 else:
                     rdatalist.append(data)
-            if len(rdatalist) > 1:
-                warn("NTUPLES: multiple real arrays, returning first one only")
-            if len(idatalist) > 1:
-                warn("NTUPLES: multiple imaginary arrays, \
-                     returning first one only")
-            if rdatalist:
-                if idatalist:
-                    data = [rdatalist[0], idatalist[0]]
-                else:
-                    data = rdatalist[0]
+            if show_all_data:
+                data = {'real': rdatalist, 'imaginary': idatalist}
             else:
-                if idatalist:
-                    data = [None, idatalist[0]]
+                if len(rdatalist) > 1:
+                    warn("NTUPLES: multiple real arrays, returning first one only")
+                if len(idatalist) > 1:
+                    warn("NTUPLES: multiple imaginary arrays, \
+                         returning first one only")
+                if rdatalist:
+                    if idatalist:
+                        data = [rdatalist[0], idatalist[0]]
+                    else:
+                        data = rdatalist[0]
+                else:
+                    if idatalist:
+                        data = [None, idatalist[0]]
 
     if data is None:  # XYDATA
         try:
@@ -558,11 +569,18 @@ def getdataarray(dic):
     # apply YFACTOR to data if available
     if is_ntuples:
         yfactor_r, yfactor_i = find_yfactors(dic)
-        if yfactor_r is None or yfactor_r is None:
+        if yfactor_r is None or yfactor_i is None:
             warn("NTUPLES: YFACTORs not applied, parsing failed")
+        elif show_all_data:
+            for i in range(len(data['real'])):
+                data['real'][i] = data['real'][i] * yfactor_r
+            for i in range(len(data['imaginary'])):
+                data['imaginary'][i] = data['imaginary'][i] * yfactor_i
         else:
-            data[0] = data[0] * yfactor_r
-            data[1] = data[1] * yfactor_i
+            if data[0] is not None:
+                data[0] = data[0] * yfactor_r
+            if data[1] is not None:
+                data[1] = data[1] * yfactor_i
     else:
         try:
             yfactor = float(dic["YFACTOR"][0])
@@ -575,7 +593,7 @@ def getdataarray(dic):
     return data
 
 
-def read(filename):
+def read(filename, show_all_data=False):
     """
     Read JCAMP-DX file
 
@@ -583,6 +601,11 @@ def read(filename):
     ----------
     filename : str
         File to read from.
+    show_all_data : bool
+        If True and data is NTUPLES, return all data arrays as a dict
+        with keys 'real' and 'imaginary', each containing a list of
+        numpy arrays. If False (default), return only the first real
+        and imaginary arrays.
 
     Returns
     -------
@@ -591,8 +614,10 @@ def read(filename):
         file, parameters of first NMR SPECTRUM or NMR FID are read to base
         level and others are stored under _datatype_<DATATYPE> keys in the
         dictionary.
-    data : ndarray
-        Array of NMR data, or a list NMR data arrays in order [real, imaginary]
+    data : ndarray or dict
+        Array of NMR data, or a list of NMR data arrays in order
+        [real, imaginary]. When show_all_data=True and data is NTUPLES,
+        a dict with keys 'real' and 'imaginary' is returned.
     """
 
     if os.path.isfile(filename) is not True:
@@ -611,7 +636,7 @@ def read(filename):
     try:
         subdiclist = dic["_datatype_NMRSPECTRUM"]
         for subdic in subdiclist:
-            data = getdataarray(subdic)
+            data = getdataarray(subdic, show_all_data)
             if data is not None:
                 correctdic = subdic
                 break
@@ -623,7 +648,7 @@ def read(filename):
         try:
             subdiclist = dic["_datatype_NMRFID"]
             for subdic in subdiclist:
-                data = getdataarray(subdic)
+                data = getdataarray(subdic, show_all_data)
                 if data is not None:
                     correctdic = subdic
                     break
@@ -636,7 +661,7 @@ def read(filename):
         try:
             subdiclist = dic["_datatype_NA"]
             for subdic in subdiclist:
-                data = getdataarray(subdic)
+                data = getdataarray(subdic, show_all_data)
                 if data is not None:
                     correctdic = subdic
                     break

--- a/nmrglue/fileio/jcampdx.py
+++ b/nmrglue/fileio/jcampdx.py
@@ -1,5 +1,9 @@
 """
-Functions for reading 1D JCAMP-DX files.
+Functions for reading JCAMP-DX files.
+
+The interface is oriented towards 1D data. Multidimensional NTUPLES spectra
+can be read, as the set of 1D pages they are stored as, but guess_udic
+describes their direct dimension only.
 """
 
 import os
@@ -429,6 +433,24 @@ def _parse_pseudo(datalines):
     return data
 
 
+# variable list of a data table header, e.g. (X++(R..R)) or (F2++(Y..Y)):
+# the first symbol is the abscissa, the second the dependent variable
+_VARIABLE_LIST_RE = re.compile(
+    r"\(\s*([A-Za-z][A-Za-z0-9]*)\s*\+\+\s*\(\s*([A-Za-z][A-Za-z0-9]*)\s*\.\.")
+
+
+def _parse_variable_list(headerline):
+    '''
+    Finds the variable symbols declared by a data table header, e.g.
+    "(X++(R..R))" gives ("X", "R") and "(F2++(Y..Y))" gives ("F2", "Y").
+    Returns (None, None) when the header declares no variable list.
+    '''
+    match = _VARIABLE_LIST_RE.search(headerline)
+    if match is None:
+        return (None, None)
+    return match.group(1), match.group(2)
+
+
 def _parse_data(datastring):
     '''
     Creates numpy array from datalines
@@ -436,14 +458,11 @@ def _parse_data(datastring):
     datalines = datastring.split("\n")
     headerline = datalines[0]
 
-    # the dependent variable symbol is declared in the variable list
-    # of the header line, e.g. (X++(R..R)) -> R, (F2++(Y..Y)) -> Y
-    datatype = "R"
-    match = re.search(
-        r"\(\s*[A-Za-z][A-Za-z0-9]*\s*\+\+\s*\(\s*([A-Za-z][A-Za-z0-9]*)\s*\.\.",
-        headerline)
-    if match:
-        datatype = match.group(1)
+    # the dependent variable is named by the header's variable list; headers
+    # that declare none are assumed to hold the real component
+    datatype = _parse_variable_list(headerline)[1]
+    if datatype is None:
+        datatype = "R"
 
     datalines = datalines[1:]  # get rid of the header line (e.g. (X++(Y..Y)))
     mode = _detect_format(datalines[0])
@@ -625,45 +644,21 @@ def read(filename, show_all_data=False):
     # and newlines
     dic = _readrawdic(filename)
 
-    # select the relevant data section.
-    # first try to parse NMRSPECTRUM sections in order,
-    # and go with first that has proper data:
+    # select the relevant data section, taking the first section of the most
+    # preferred DATATYPE that yields data. Non-typed sections are tried
+    # because the DATATYPE label is sometimes missing, and multidimensional
+    # spectra come last so that a file offering both a 1D and an nD spectrum
+    # keeps returning the 1D one.
     data = None
     correctdic = None
-    try:
-        subdiclist = dic["_datatype_NMRSPECTRUM"]
-        for subdic in subdiclist:
+    for datatype in ("NMRSPECTRUM", "NMRFID", "NA", "NDNMRSPECTRUM"):
+        for subdic in dic.get("_datatype_" + datatype, []):
             data = getdataarray(subdic, show_all_data)
             if data is not None:
                 correctdic = subdic
                 break
-    except KeyError:
-        pass
-
-    if data is None:
-        # then try NMRFIDs:
-        try:
-            subdiclist = dic["_datatype_NMRFID"]
-            for subdic in subdiclist:
-                data = getdataarray(subdic, show_all_data)
-                if data is not None:
-                    correctdic = subdic
-                    break
-        except KeyError:
-            pass
-
-    if data is None:
-        # finally try all non-typed data sections, since
-        # sometimes DATATYPE label may be missing
-        try:
-            subdiclist = dic["_datatype_NA"]
-            for subdic in subdiclist:
-                data = getdataarray(subdic, show_all_data)
-                if data is not None:
-                    correctdic = subdic
-                    break
-        except KeyError:
-            pass
+        if data is not None:
+            break
 
     if data is None:
         warn("no data found either in XYDATA or NTUPLES format")
@@ -697,6 +692,35 @@ def read(filename, show_all_data=False):
     return dic, data
 
 
+def _find_abscissa_symbol(dic, symbols):
+    '''
+    Finds which of an NTUPLES variable list's symbols is the abscissa.
+    One dimensional data calls it X, while multidimensional data names its
+    dimensions instead. In that case the innermost, i.e. last, independent
+    variable is the abscissa of every page: a file declaring (F1, F2, Y)
+    stores (F2++(Y..Y)) data tables, one per value of F1.
+    Returns None if it cannot be identified.
+    '''
+    if "X" in symbols:
+        return "X"
+
+    try:
+        vartypes = [s.strip().upper() for s in dic["VARTYPE"][0].split(",")]
+        independent = [symbol for symbol, vartype in zip(symbols, vartypes)
+                       if vartype == "INDEPENDENT"]
+        if independent:
+            return independent[-1]
+    except (KeyError, IndexError):
+        pass
+
+    # no VARTYPE to go on: fall back to the abscissa a data table declares,
+    # available while reading but not after read() strips the tables
+    try:
+        return _parse_variable_list(dic["DATATABLE"][0].split("\n", 1)[0])[0]
+    except (KeyError, IndexError):
+        return None
+
+
 def _find_firstx_lastx(dic):
     '''
     Helper for guess_udic: seeks firstx and lastx for
@@ -713,12 +737,12 @@ def _find_firstx_lastx(dic):
     is_ntuples = get_is_ntuples(dic)
 
     if is_ntuples:
-        # first check which column is X:
+        # first check which column is the abscissa:
         index_x = None
         try:
             symbols = dic["SYMBOL"][0].split(",")
             symbols = [s.strip() for s in symbols]
-            index_x = symbols.index("X")
+            index_x = symbols.index(_find_abscissa_symbol(dic, symbols))
         except (KeyError, IndexError, ValueError):
             warn("Cannot found X column on NTUPLES")
         if index_x is not None:
@@ -788,7 +812,16 @@ def guess_udic(dic, data):
     # create an empty universal dictionary
     udic = fileiobase.create_blank_udic(1)
 
-    # update default values (currently only 1D possible)
+    # the universal dictionary is one dimensional, so for multidimensional
+    # data it can only describe the direct dimension
+    try:
+        if int(dic["NUMDIM"][0]) > 1:
+            warn("Multidimensional data: udic describes the direct "
+                 "dimension only")
+    except (KeyError, IndexError, ValueError):
+        pass
+
+    # update default values
     # "label"
     try:
         label_value = dic[".OBSERVENUCLEUS"][0].replace("^", "")
@@ -812,6 +845,11 @@ def guess_udic(dic, data):
         pass
 
     # "size"
+    if isinstance(data, dict):
+        # show_all_data form: every page has the same length, so measure the
+        # first one that is present
+        pages = data.get("real") or data.get("imaginary") or [None]
+        data = pages[0]
     if isinstance(data, list):
         data = data[0]  # if list [R,I]
     if data is not None:

--- a/nmrglue/fileio/jcampdx.py
+++ b/nmrglue/fileio/jcampdx.py
@@ -436,9 +436,14 @@ def _parse_data(datastring):
     datalines = datastring.split("\n")
     headerline = datalines[0]
 
+    # the dependent variable symbol is declared in the variable list
+    # of the header line, e.g. (X++(R..R)) -> R, (F2++(Y..Y)) -> Y
     datatype = "R"
-    if "I..I" in headerline:
-        datatype = "I"
+    match = re.search(
+        r"\(\s*[A-Za-z][A-Za-z0-9]*\s*\+\+\s*\(\s*([A-Za-z][A-Za-z0-9]*)\s*\.\.",
+        headerline)
+    if match:
+        datatype = match.group(1)
 
     datalines = datalines[1:]  # get rid of the header line (e.g. (X++(Y..Y)))
     mode = _detect_format(datalines[0])
@@ -467,32 +472,27 @@ def get_is_ntuples(dic):
     return is_ntuples
 
 
+def find_factor(dic, symbol):
+    '''
+    Helper to find the scaling factor of the given symbol (e.g. "R", "I"
+    or "Y") from the NTUPLES ##SYMBOL= and ##FACTOR= records, whose
+    comma-separated entries correspond by position.
+    Returns None if the factor cannot be determined.
+    '''
+    try:
+        symbols = [s.strip() for s in dic["SYMBOL"][0].split(",")]
+        factors = [s.strip() for s in dic["FACTOR"][0].split(",")]
+        return float(factors[symbols.index(symbol)])
+    except (KeyError, IndexError, ValueError):
+        return None
+
+
 def find_yfactors(dic):
     '''
     Helper to find yfactors from NTUPLES format.
     Returns YFactors in tuple with order (R,I)
     '''
-
-    # first check which column is R and I:
-    index_r = None
-    index_i = None
-    try:
-        symbols = dic["SYMBOL"][0].split(",")
-        symbols = [s.strip() for s in symbols]
-        index_r = symbols.index("R")
-        index_i = symbols.index("I")
-    except (KeyError, IndexError, ValueError):
-        return (None, None)
-
-    try:
-        factors = dic["FACTOR"][0].split(",")
-        factors = [s.strip() for s in factors]
-        factor_r = float(factors[index_r])
-        factor_i = float(factors[index_i])
-    except (KeyError, IndexError, ValueError):
-        return (None, None)
-
-    return (factor_r, factor_i)
+    return (find_factor(dic, "R"), find_factor(dic, "I"))
 
 
 def getdataarray(dic, show_all_data=False):
@@ -529,6 +529,16 @@ def getdataarray(dic, show_all_data=False):
                 if parseret is None:
                     return None
                 data, datatype = parseret
+                # scale by the factor of this table's own dependent
+                # symbol: an (X++(I..I)) table gets I's factor, an
+                # (X++(R..R)) table R's, so factors can never be
+                # applied to the wrong component
+                factor = find_factor(dic, datatype)
+                if factor is None:
+                    warn("NTUPLES: no FACTOR found for symbol %s, "
+                         "data not scaled" % datatype)
+                else:
+                    data = data * factor
                 if datatype == "I":
                     idatalist.append(data)
                 else:
@@ -567,21 +577,8 @@ def getdataarray(dic, show_all_data=False):
         return None
 
     # apply YFACTOR to data if available
-    if is_ntuples:
-        yfactor_r, yfactor_i = find_yfactors(dic)
-        if yfactor_r is None or yfactor_i is None:
-            warn("NTUPLES: YFACTORs not applied, parsing failed")
-        elif show_all_data:
-            for i in range(len(data['real'])):
-                data['real'][i] = data['real'][i] * yfactor_r
-            for i in range(len(data['imaginary'])):
-                data['imaginary'][i] = data['imaginary'][i] * yfactor_i
-        else:
-            if data[0] is not None:
-                data[0] = data[0] * yfactor_r
-            if data[1] is not None:
-                data[1] = data[1] * yfactor_i
-    else:
+    # (NTUPLES data was already scaled per-table above)
+    if not is_ntuples:
         try:
             yfactor = float(dic["YFACTOR"][0])
             data = data * yfactor

--- a/tests/test_jcampdx.py
+++ b/tests/test_jcampdx.py
@@ -241,10 +241,10 @@ def test_jcampdx_show_all_data():
         "##FACTOR=1, 2.5, 5.0\n"
         "##PAGE=N=1\n"
         "##DATA TABLE=(X++(R..R)), R\n"
-        "1.0 10 20\n"
+        "1.0 10 20 30\n"
         "##PAGE=N=2\n"
         "##DATA TABLE=(X++(I..I)), I\n"
-        "1.0 100 200\n"
+        "1.0 100 200 300\n"
         "##END=\n"
     )
 
@@ -257,8 +257,8 @@ def test_jcampdx_show_all_data():
         dic, data = ng.jcampdx.read(path, show_all_data=False)
         assert len(data) == 2
         # YFACTOR applied: R factor=2.5, I factor=5.0
-        assert np.allclose(data[0], [25.0, 50.0])
-        assert np.allclose(data[1], [500.0, 1000.0])
+        assert np.allclose(data[0], [25.0, 50.0, 75.0])
+        assert np.allclose(data[1], [500.0, 1000.0, 1500.0])
 
         # Test show_all_data=True (returns {'real': [...], 'imaginary': [...]})
         dic, data_all = ng.jcampdx.read(path, show_all_data=True)
@@ -267,8 +267,13 @@ def test_jcampdx_show_all_data():
         assert 'imaginary' in data_all
         assert len(data_all['real']) == 1
         assert len(data_all['imaginary']) == 1
-        assert np.allclose(data_all['real'][0], [25.0, 50.0])
-        assert np.allclose(data_all['imaginary'][0], [500.0, 1000.0])
+        assert np.allclose(data_all['real'][0], [25.0, 50.0, 75.0])
+        assert np.allclose(data_all['imaginary'][0], [500.0, 1000.0, 1500.0])
+
+        # size comes from a page, not from the dict's two keys, which a
+        # two-point spectrum would have hidden
+        udic = ng.jcampdx.guess_udic(dic, data_all)
+        assert udic[0]["size"] == 3
     finally:
         os.remove(path)
 
@@ -334,5 +339,95 @@ def test_jcampdx_ntuples_symbol_factor_missing():
             _, data_all = ng.jcampdx.read(path, show_all_data=True)
         assert np.allclose(data_all['real'][0], [10.0, 20.0])
         assert np.allclose(data_all['real'][1], [30.0, 40.0])
+    finally:
+        os.remove(path)
+
+
+# a two dimensional spectrum, stored the way JEOL, MestReNova and Bruker
+# write them: DATATYPE nD NMR SPECTRUM, one (F2++(Y..Y)) page per F1 value
+_ND_SPECTRUM = (
+    "##TITLE=Test nD NTUPLES\n"
+    "##JCAMPDX=6.0\n"
+    "##DATATYPE=nD NMR SPECTRUM\n"
+    "##DATA CLASS=NTUPLES\n"
+    "##NUM DIM=2\n"
+    "##.OBSERVE FREQUENCY=100.0\n"
+    "##.OBSERVE NUCLEUS=^1H\n"
+    "##NTUPLES=nD NMR SPECTRUM\n"
+    "##VAR_NAME=FREQUENCY1, FREQUENCY2, SPECTRUM\n"
+    "##SYMBOL=F1, F2, Y\n"
+    "##VAR_TYPE=INDEPENDENT, INDEPENDENT, DEPENDENT\n"
+    "##VAR_FORM=AFFN, AFFN, ASDF\n"
+    "##UNITS=HZ, HZ, ARBITRARY UNITS\n"
+    "##FIRST=500, 400, 10\n"
+    "##LAST=100, 200, 40\n"
+    "##FACTOR=1, 1, 2.0\n"
+    "##PAGE=F1=500\n"
+    "##DATA TABLE=(F2++(Y..Y)), PROFILE\n"
+    "1.0 10 20\n"
+    "##PAGE=F1=100\n"
+    "##DATA TABLE=(F2++(Y..Y)), PROFILE\n"
+    "1.0 30 40\n"
+    "##END=\n"
+)
+
+
+def test_jcampdx_read_nd_spectrum():
+    '''JCAMP-DX read: nD NMR SPECTRUM sections are found and scaled'''
+    path = _write_jcamp(_ND_SPECTRUM)
+    try:
+        dic, data_all = ng.jcampdx.read(path, show_all_data=True)
+
+        # every page is present, and scaled by Y's factor
+        assert len(data_all['real']) == 2
+        assert np.allclose(data_all['real'][0], [20.0, 40.0])
+        assert np.allclose(data_all['real'][1], [60.0, 80.0])
+
+        # the section's parameters were promoted, as for any other datatype
+        assert dic["DATATYPE"][0] == "nD NMR SPECTRUM"
+
+        # the udic describes the direct dimension: F2 is the abscissa of each
+        # page, so the sweep comes from F2's FIRST and LAST and not F1's
+        with pytest.warns(UserWarning, match="direct dimension only"):
+            udic = ng.jcampdx.guess_udic(dic, data_all)
+        assert udic[0]["size"] == 2
+        assert udic[0]["sw"] == 200.0
+        assert udic[0]["obs"] == 100.0
+        assert udic[0]["label"] == "1H"
+    finally:
+        os.remove(path)
+
+
+def test_jcampdx_prefers_1d_over_nd():
+    '''JCAMP-DX read: a 1D section wins over an nD one in the same file'''
+    # LINK file holding both, as Bruker and MestReNova write for 2D datasets
+    content = (
+        "##TITLE=Both\n"
+        "##JCAMPDX=6.0\n"
+        "##DATATYPE=LINK\n"
+        "##BLOCKS=2\n"
+        + _ND_SPECTRUM +
+        "##TITLE=The 1D part\n"
+        "##JCAMPDX=5.0\n"
+        "##DATATYPE=NMR SPECTRUM\n"
+        "##DATA CLASS=XYDATA\n"
+        "##FIRSTX=1\n"
+        "##LASTX=2\n"
+        "##XUNITS=HZ\n"
+        "##YFACTOR=1\n"
+        "##XYDATA=(X++(Y..Y))\n"
+        "1.0 7 8\n"
+        "##END=\n"
+        "##END=\n"
+    )
+    path = _write_jcamp(content)
+    try:
+        # the nD section is listed first but must not win, so that files which
+        # already returned their 1D spectrum keep returning it
+        dic, data = ng.jcampdx.read(path)
+        assert np.allclose(data, [7.0, 8.0])
+        assert dic["DATATYPE"][0] == "NMR SPECTRUM"
+        # the nD section is still reachable from the dic
+        assert "_datatype_NDNMRSPECTRUM" in dic
     finally:
         os.remove(path)

--- a/tests/test_jcampdx.py
+++ b/tests/test_jcampdx.py
@@ -1,6 +1,7 @@
 """ Tests for the fileio.jcampdx submodule """
 
 import os
+import tempfile
 import numpy as np
 import nmrglue as ng
 from setup import DATA_DIR
@@ -222,3 +223,50 @@ def test_jcampdx_dicstructure2():
     # check data
     assert len(data2) == 8
     assert data2[-1] == 1.0
+
+
+def test_jcampdx_show_all_data():
+    # Test NTUPLES with show_all_data=True
+    content_ntup = (
+        "##TITLE=Test NTUPLES\n"
+        "##JCAMPDX=5.0\n"
+        "##DATATYPE=NMR SPECTRUM\n"
+        "##DATA CLASS=NTUPLES\n"
+        "##NUM DIM=1\n"
+        "##SYMBOL=X, R, I\n"
+        "##VARNAME=FREQUENCY, REAL, IMAGINARY\n"
+        "##VARTYPE=RANDOM, DEPENDENT, DEPENDENT\n"
+        "##VARFORM=(X++(R..R))\n"
+        "##FACTOR=1, 2.5, 5.0\n"
+        "##PAGE=N=1\n"
+        "##DATA TABLE=(X++(R..R)), R\n"
+        "1.0 10 20\n"
+        "##PAGE=N=2\n"
+        "##DATA TABLE=(X++(I..I)), I\n"
+        "1.0 100 200\n"
+        "##END=\n"
+    )
+
+    fd, path = tempfile.mkstemp()
+    try:
+        with os.fdopen(fd, 'w') as f:
+            f.write(content_ntup)
+
+        # Test normal read (returns only first real & imaginary arrays)
+        dic, data = ng.jcampdx.read(path, show_all_data=False)
+        assert len(data) == 2
+        # YFACTOR applied: R factor=2.5, I factor=5.0
+        assert np.allclose(data[0], [25.0, 50.0])
+        assert np.allclose(data[1], [500.0, 1000.0])
+
+        # Test show_all_data=True (returns {'real': [...], 'imaginary': [...]})
+        dic, data_all = ng.jcampdx.read(path, show_all_data=True)
+        assert isinstance(data_all, dict)
+        assert 'real' in data_all
+        assert 'imaginary' in data_all
+        assert len(data_all['real']) == 1
+        assert len(data_all['imaginary']) == 1
+        assert np.allclose(data_all['real'][0], [25.0, 50.0])
+        assert np.allclose(data_all['imaginary'][0], [500.0, 1000.0])
+    finally:
+        os.remove(path)

--- a/tests/test_jcampdx.py
+++ b/tests/test_jcampdx.py
@@ -3,6 +3,7 @@
 import os
 import tempfile
 import numpy as np
+import pytest
 import nmrglue as ng
 from setup import DATA_DIR
 
@@ -268,5 +269,70 @@ def test_jcampdx_show_all_data():
         assert len(data_all['imaginary']) == 1
         assert np.allclose(data_all['real'][0], [25.0, 50.0])
         assert np.allclose(data_all['imaginary'][0], [500.0, 1000.0])
+    finally:
+        os.remove(path)
+
+
+# NTUPLES data whose dependent variable is declared as something other
+# than R/I, as written by JEOL/MestReNova and Bruker for 2D spectra: the
+# variable list is (F1, F2, Y) and every page is an (F2++(Y..Y)) table.
+_NTUPLES_Y_TEMPLATE = (
+    "##TITLE=Test NTUPLES with Y symbol\n"
+    "##JCAMPDX=6.0\n"
+    "##DATATYPE=NMR SPECTRUM\n"
+    "##DATA CLASS=NTUPLES\n"
+    "##NUM DIM=2\n"
+    "##NTUPLES=NMR SPECTRUM\n"
+    "##VAR_NAME=FREQUENCY1, FREQUENCY2, SPECTRUM\n"
+    "##SYMBOL=F1, F2, Y\n"
+    "##VAR_TYPE=INDEPENDENT, INDEPENDENT, DEPENDENT\n"
+    "##VAR_FORM=AFFN, AFFN, ASDF\n"
+    "%s"
+    "##PAGE=F1=1\n"
+    "##DATA TABLE=(F2++(Y..Y)), PROFILE\n"
+    "1.0 10 20\n"
+    "##PAGE=F1=2\n"
+    "##DATA TABLE=(F2++(Y..Y)), PROFILE\n"
+    "1.0 30 40\n"
+    "##END=\n"
+)
+
+
+def _write_jcamp(content):
+    fd, path = tempfile.mkstemp()
+    with os.fdopen(fd, 'w') as f:
+        f.write(content)
+    return path
+
+
+def test_jcampdx_ntuples_symbol_factor():
+    '''NTUPLES FACTOR is picked by the table's own dependent symbol'''
+    # Y is the third entry of SYMBOL, so its factor is the third of FACTOR
+    path = _write_jcamp(_NTUPLES_Y_TEMPLATE % "##FACTOR=1, 1, 2.0\n")
+    try:
+        # all pages, each scaled by Y's factor and not by F1's or F2's
+        _, data_all = ng.jcampdx.read(path, show_all_data=True)
+        assert isinstance(data_all, dict)
+        assert len(data_all['real']) == 2
+        assert data_all['imaginary'] == []
+        assert np.allclose(data_all['real'][0], [20.0, 40.0])
+        assert np.allclose(data_all['real'][1], [60.0, 80.0])
+
+        # the single-array form is scaled identically
+        _, data = ng.jcampdx.read(path, show_all_data=False)
+        assert np.allclose(data, [20.0, 40.0])
+    finally:
+        os.remove(path)
+
+
+def test_jcampdx_ntuples_symbol_factor_missing():
+    '''NTUPLES data is left unscaled, with a warning, if its FACTOR is absent'''
+    # FACTOR declares only the two independent variables, so Y has none
+    path = _write_jcamp(_NTUPLES_Y_TEMPLATE % "##FACTOR=1, 1\n")
+    try:
+        with pytest.warns(UserWarning, match="no FACTOR found for symbol Y"):
+            _, data_all = ng.jcampdx.read(path, show_all_data=True)
+        assert np.allclose(data_all['real'][0], [10.0, 20.0])
+        assert np.allclose(data_all['real'][1], [30.0, 40.0])
     finally:
         os.remove(path)


### PR DESCRIPTION
### Summary

Adds support for reading multidimensional NTUPLES spectra. `read()` now finds `nD NMR SPECTRUM` sections, `show_all_data` returns every page from them, and each page is scaled by the factor belonging to its own dependent variable.

### Background

NTUPLES data appears in two shapes in NMR JCAMP-DX files. One-dimensional spectra and FIDs declare a variable list of `(X, R, I)` and store one page per component. Two-dimensional spectra declare `(F1, F2, Y)` and store one `(F2++(Y..Y))` page per point of the indirect dimension, in a section labelled `##DATA TYPE= nD NMR SPECTRUM`.

The reader handled the first shape only. The second was never reached, because `read()` consulted just `NMR SPECTRUM`, `NMR FID` and untyped sections; and the helpers that apply scaling factors and locate the abscissa were written around
the symbols `R`, `I` and `X` specifically, so they had nothing to match in an `(F1, F2, Y)` variable list.

### Changes

**`51eeedf` — add the `show_all_data` parameter**

- `read()` and `getdataarray()` take `show_all_data` (default `False`). When `True` they return `{'real': [array, ...], 'imaginary': [array, ...]}` with every parsed page; when `False` behaviour is unchanged.
- Fix a typo in the YFACTOR null check, `yfactor_r is None or yfactor_r is None` → `... or yfactor_i is None`, which
  meant `yfactor_i` was never checked.
- Add `None`-safety for single-component NTUPLES data.

**`177430e` — scale each table by its own dependent variable**

`find_yfactors` requires **both** `R` and `I` to appear in `##SYMBOL=` and returns `(None, None)` otherwise, so a variable list of `(F1, F2, Y)` produced unscaled data behind a warning that reported a parsing failure.

- The dependent variable is now taken from the data table's own header: `(X++(R..R))` gives `R`, `(F2++(Y..Y))` gives `Y`.
- Each table is scaled by the factor belonging to its own symbol, so a factor cannot be applied to the wrong component, and the two scaling loops that differed between the `show_all_data` modes collapse into one path.
- A missing factor warns per symbol rather than reporting a YFACTOR parsing failure.

**`ff18f93` — read multidimensional NTUPLES spectra**

- `read()` also tries `nD NMR SPECTRUM` sections. It tries them **last**, after `NMR SPECTRUM`, `NMR FID` and untyped sections, so a file offering both a 1D and an nD spectrum keeps returning the 1D one.
- The four near-identical section lookups become one loop over the DATATYPEs in preference order.
- `_find_firstx_lastx` no longer assumes the abscissa is called `X`. Multidimensional data names its dimensions instead, and the abscissa of each page is the innermost independent variable: a file declaring `(F1, F2, Y)` stores `(F2++(Y..Y))` tables, so the sweep comes from `F2` and not `F1`. The symbol is resolved from `##VARTYPE=`, which survives `read()` stripping the
  data tables from the returned dictionary.
- `guess_udic` measured a `show_all_data` dict with `len()`, giving the number of keys rather than the length of a page. It now measures a page, and warns that it describes the direct dimension only when `##NUM DIM=` is greater than one.
- The module docstring no longer describes the reader as 1D only.

### Testing

New self-contained tests, in the existing `tempfile` style:

- `test_jcampdx_show_all_data` -- both modes, and that `guess_udic` measures a page rather than the dict's key count.
- `test_jcampdx_ntuples_symbol_factor` -- each page is scaled by `Y`'s factor and not by `F1`'s or `F2`'s, in both modes.
- `test_jcampdx_ntuples_symbol_factor_missing` -- data is left unscaled, with a warning naming the symbol, when `##FACTOR=` has no entry for it.
- `test_jcampdx_read_nd_spectrum` -- an `nD NMR SPECTRUM` section is found and scaled, and its udic sweep is taken from `F2`.
- `test_jcampdx_prefers_1d_over_nd` -- a 1D section still wins over an nD one in the same file. This passes before and after the change; it guards the preference order against future reordering.

Each commit passes its own tests standing alone, so the branch is bisectable. The four pre-existing failures in `tests/test_jcampdx.py`, which come from the external test-data directory not being present, are unchanged and identical at every commit.
