### PR TITLE
fix(bruker): decode JCAMP parameter files losslessly, independent of locale

### DIFF
--- a/nmrglue/fileio/bruker.py
+++ b/nmrglue/fileio/bruker.py
@@ -4,7 +4,6 @@ JCAMP-DX parameter (acqus) files, and Bruker pulse program (pulseprogram)
 files.
 """
 
-import locale
 import io
 
 __developer_info__ = """
@@ -2166,7 +2165,7 @@ def rm_dig_filter(
 
 # JCAMP-DX functions
 
-def read_jcamp(filename, encoding=locale.getpreferredencoding()):
+def read_jcamp(filename, encoding=None):
     """
     Read a Bruker JCAMP-DX file into a dictionary.
 
@@ -2178,8 +2177,11 @@ def read_jcamp(filename, encoding=locale.getpreferredencoding()):
     ----------
     filename : str
         Filename of Bruker JCAMP-DX file.
-    encoding : str
-        Encoding of Bruker JCAMP-DX file. Defaults to the system default locale.
+    encoding : str, optional
+        Encoding of Bruker JCAMP-DX file. When given, it is tried first;
+        otherwise (and on failure) the file is decoded by trying utf-8,
+        cp1252 and latin-1 in order, using the first that decodes without
+        error. As latin-1 maps every byte, reading never fails on decoding.
 
     Returns
     -------
@@ -2197,18 +2199,35 @@ def read_jcamp(filename, encoding=locale.getpreferredencoding()):
 
     """
     dic = {"_coreheader": [], "_comments": []}  # create empty dictionary
-    try:
-        with open(filename, 'r', encoding=encoding) as f:
-            dic=parse_jcamp_file(f,dic)
-    except:
-        if encoding == "utf-8":
-            with open(filename, 'r', encoding="cp1252") as f:
-                dic=parse_jcamp_file(f,dic)
-        else:
-            with open(filename, 'r', encoding="utf-8") as f:
-                dic=parse_jcamp_file(f,dic)
 
-    return dic
+    with open(filename, 'rb') as f:
+        raw = f.read()
+
+    # utf-8-sig rather than utf-8 so that a byte order mark is consumed
+    # instead of being left on the first line, where it would stop ##TITLE=
+    # from being recognised. It decodes BOM-less files identically to utf-8.
+    codecs_to_try = []
+    for enc in ([encoding] if encoding is not None else []) + \
+            ['utf-8-sig', 'cp1252', 'latin-1']:
+        if enc not in codecs_to_try:
+            codecs_to_try.append(enc)
+
+    # strict decoding with each candidate in turn: a wrongly-guessed codec
+    # raises instead of silently corrupting characters. latin-1 decodes any
+    # byte sequence, so the loop always produces text.
+    for enc in codecs_to_try:
+        try:
+            text = raw.decode(enc)
+            break
+        except UnicodeDecodeError:
+            continue
+
+    if enc == 'latin-1' and enc != codecs_to_try[0]:
+        warn("%s: could not be decoded as %s; fell back to latin-1, "
+             "non-ASCII characters may be incorrect."
+             % (filename, " or ".join(codecs_to_try[:-1])))
+
+    return parse_jcamp_file(io.StringIO(text), dic)
 
 def parse_jcamp_file(f,dic):
     """

--- a/nmrglue/fileio/tests/test_bruker.py
+++ b/nmrglue/fileio/tests/test_bruker.py
@@ -1,8 +1,10 @@
 """ Unit tests for nmrglue/fileio/bruker.py module """
 
 import os
+import warnings
 
 import numpy as np
+import pytest
 import nmrglue as ng
 import shutil
 import tempfile
@@ -80,3 +82,81 @@ def test_write_pdata():
     assert np.all(data == rdata)
     assert rdic['procs'].keys() == dic['procs'].keys()
     shutil.rmtree(td)
+
+
+def _real_acqus_bytes():
+    """Bytes of the real acqus file shipped with the test data."""
+    with open(os.path.join(DATA_DIR, '1', 'acqus'), 'rb') as f:
+        return f.read()
+
+
+def _write_temp(content):
+    fd, temp_path = tempfile.mkstemp()
+    with os.fdopen(fd, 'wb') as f:
+        f.write(content)
+    return temp_path
+
+
+def test_read_jcamp_cp1252():
+    """cp1252-encoded acqus (e.g. degree sign) decodes correctly"""
+    # real acqus with a realistic cp1252 (non utf-8) parameter added,
+    # as written by instruments configured with a western locale
+    content = _real_acqus_bytes().replace(
+        b"##END=", "##$SOLVENT= <CDCl3 at 25\u00b0C>\n##END=".encode("cp1252"))
+    temp_path = _write_temp(content)
+    try:
+        dic = ng.bruker.read_jcamp(temp_path)
+        # correct character, no U+FFFD corruption
+        assert dic["SOLVENT"] == "CDCl3 at 25\u00b0C"
+        # remainder of the real file still parsed
+        assert dic["LOCKED"] is True
+    finally:
+        os.remove(temp_path)
+
+
+def test_read_jcamp_undecodable_bytes():
+    """bytes invalid in both utf-8 and cp1252 do not crash the reader"""
+    # 0x81 is undefined in cp1252 and invalid utf-8; latin-1 fallback
+    content = _real_acqus_bytes().replace(
+        b"##END=", b"##$BAD= <\x81>\n##END=")
+    temp_path = _write_temp(content)
+    try:
+        with pytest.warns(UserWarning, match="latin-1"):
+            dic = ng.bruker.read_jcamp(temp_path)
+        assert dic["BAD"] == "\x81"  # latin-1 maps byte to same codepoint
+        assert dic["LOCKED"] is True  # rest of file intact
+    finally:
+        os.remove(temp_path)
+
+
+def test_read_jcamp_explicit_encoding():
+    """an explicit encoding is tried first"""
+    # 0xb0 is a degree sign in cp1252 but an infinity sign in mac-roman;
+    # with an explicit encoding the caller's choice must win
+    content = _real_acqus_bytes().replace(
+        b"##END=", b"##$TEMPUNIT= <\xb0C>\n##END=")
+    temp_path = _write_temp(content)
+    try:
+        dic = ng.bruker.read_jcamp(temp_path, encoding="mac-roman")
+        assert dic["TEMPUNIT"] == "\u221eC"
+        dic = ng.bruker.read_jcamp(temp_path)
+        assert dic["TEMPUNIT"] == "\u00b0C"
+    finally:
+        os.remove(temp_path)
+
+
+def test_read_jcamp_utf8_bom():
+    """a byte order mark does not hide the first record"""
+    content = b"\xef\xbb\xbf" + _real_acqus_bytes()
+    temp_path = _write_temp(content)
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            dic = ng.bruker.read_jcamp(temp_path)
+        # left in place, the BOM makes ##TITLE= unrecognisable and it is
+        # discarded as an extraneous line
+        assert not [w for w in caught if "Extraneous line" in str(w.message)]
+        assert dic["_coreheader"][0].startswith("##TITLE=")
+        assert dic["LOCKED"] is True  # remainder of the real file still parsed
+    finally:
+        os.remove(temp_path)


### PR DESCRIPTION
### Summary

`read_jcamp()` decodes Bruker JCAMP-DX parameter files by trying a fixed sequence of codecs strictly and taking the first that decodes without error. Decoding no longer depends on the machine's locale, correctly encoded files are never given replacement characters, and reading does not fail on a decoding error.

### Background

`read_jcamp()` takes `encoding=locale.getpreferredencoding()` as a default argument. A default argument is evaluated once, when the module is imported, so the codec is fixed by whatever locale the interpreter started under and the same
file can be parsed differently on two machines. If opening with that codec raises, a bare `except:` retries with `cp1252` or `utf-8`, and if the retry also fails the error propagates to the caller.

### Changes

- `encoding` now defaults to `None`, and `import locale` is dropped, so nothing about the parse depends on the environment.
- The file is read as bytes and decoded strictly, trying the explicit `encoding` argument first when one is given, then `utf-8-sig`, `cp1252` and `latin-1`. The first codec that decodes without error wins.
- Decoding strictly means a wrongly guessed codec raises and the next candidate is tried, rather than producing U+FFFD, so a correctly encoded file is not silently altered.
- `latin-1` maps every byte value, so the sequence always yields text and reading does not fail on a decoding error. A warning is emitted when it is reached, naming the file and the codecs that were tried.
- `utf-8-sig` is preferred over `utf-8` so that a byte order mark is consumed instead of being left on the first line, where it stopped `##TITLE=` from being recognised and cost the title its entry in `_coreheader`. It decodes files without a byte order mark identically to `utf-8`, and it is what `jcampdx.py` already uses to open `.jdx` files.
- The bare `except:` is gone, so errors unrelated to decoding are no longer swallowed and retried.

### Testing

Four new tests, each built on the real `acqus` file already shipped in `bruker_test_data` rather than a synthetic stub:

- `test_read_jcamp_cp1252` -- a cp1252 parameter value (a degree sign, as written by instruments configured for a western locale) decodes to the correct character, with no U+FFFD, and the rest of the file still parses.
- `test_read_jcamp_undecodable_bytes` -- a byte that is invalid in both `utf-8` and `cp1252` does not stop the read; the latin-1 warning is raised and the remaining parameters are intact.
- `test_read_jcamp_explicit_encoding` -- an explicit `encoding` argument is tried first, checked with a byte that means different characters in `mac-roman` and `cp1252`.
- `test_read_jcamp_utf8_bom` — a byte order mark does not hide the first record.

All existing tests continue to pass.

### Note

Passing `encoding=` an unknown codec name raises `LookupError`, as it did before; only decoding errors are handled by the sequence above.