### PR TITLE
feat(jcampdx): add support for coordinate list (XY..XY) format, PEAKTABLE/XYPOINTS parsing, and comma decimal separators

### DIFF
--- a/nmrglue/fileio/jcampdx.py
+++ b/nmrglue/fileio/jcampdx.py
@@ -226,8 +226,13 @@ def _detect_format(dataline):
     Detects and returns digit format:
     0  Normal
     1  Pseudodigits
+    2  Coordinate list (XY..XY)
     -1 Error
     '''
+    # check for coordinate list first
+    xy_re = re.compile(r'^[0-9.]+(?:[eE][+-]?\d+)?,\s?[0-9.]+(?:[eE][+-]?\d+)?')
+    if re.search(xy_re, dataline):
+        return 2
 
     # regexp to find & skip the first value of line, that never begins
     # with a pseudodigit in any format
@@ -429,10 +434,33 @@ def _parse_pseudo(datalines):
     return data
 
 
+def _parse_xy_xy(datalines):
+    '''
+    Parses datalines in coordinate list format (XY..XY),
+    where each line contains comma-separated X,Y pairs.
+    '''
+    pts = []
+    xy_pair_re = re.compile(
+        r"([+-]?\d+\.?\d*(?:[eE][+-]?\d+)?)\s*,\s*"
+        r"([+-]?\d+\.?\d*(?:[eE][+-]?\d+)?)"
+    )
+    for dataline in datalines:
+        for match in xy_pair_re.finditer(dataline):
+            x = float(match.group(1))
+            y = float(match.group(2))
+            pts.append([x, y])
+    return [pts]
+
+
 def _parse_data(datastring):
     '''
     Creates numpy array from datalines
     '''
+    header_end = datastring.find('\n')
+    data_part = datastring[header_end:] if header_end != -1 else datastring
+    if ',' in data_part and '.' not in data_part:
+        datastring = re.sub(r'(\d),(\d)', r'\1.\2', datastring)
+
     datalines = datastring.split("\n")
     headerline = datalines[0]
 
@@ -446,6 +474,11 @@ def _parse_data(datastring):
         data = _parse_pseudo(datalines)
     elif mode == 0:
         data = _parse_affn_pac(datalines)
+    elif mode == 2:
+        if headerline == '(X++(Y..Y))':
+            data = _parse_affn_pac(datalines)
+        else:
+            data = _parse_xy_xy(datalines)
     else:
         return None
     if data is None:
@@ -551,6 +584,30 @@ def getdataarray(dic):
             data, datatype = parseret
         except KeyError:
             warn("XYDATA not found ")
+
+    if data is None:  # PEAKTABLE
+        try:
+            valuelist = dic["PEAKTABLE"]
+            if len(valuelist) > 1:
+                warn("Multiple PEAKTABLE arrays in JCAMP-DX file, "
+                     "returning first one only")
+            parseret = _parse_data(valuelist[0])
+            if parseret is not None:
+                data, datatype = parseret
+        except KeyError:
+            pass
+
+    if data is None:  # XYPOINTS
+        try:
+            valuelist = dic["XYPOINTS"]
+            if len(valuelist) > 1:
+                warn("Multiple XYPOINTS arrays in JCAMP-DX file, "
+                     "returning first one only")
+            parseret = _parse_data(valuelist[0])
+            if parseret is not None:
+                data, datatype = parseret
+        except KeyError:
+            pass
 
     if data is None:
         return None

--- a/tests/test_jcampdx.py
+++ b/tests/test_jcampdx.py
@@ -1,6 +1,7 @@
 """ Tests for the fileio.jcampdx submodule """
 
 import os
+import tempfile
 import numpy as np
 import nmrglue as ng
 from setup import DATA_DIR
@@ -222,3 +223,105 @@ def test_jcampdx_dicstructure2():
     # check data
     assert len(data2) == 8
     assert data2[-1] == 1.0
+
+
+def test_jcampdx_parsing_improvements():
+    # 1. Test coordinate format (XY..XY)
+    content_xy = (
+        "##TITLE=Test XY\n"
+        "##JCAMPDX=5.0\n"
+        "##DATATYPE=NMR SPECTRUM\n"
+        "##DATA CLASS=XYDATA\n"
+        "##XYDATA=(X..XY)\n"
+        "1.0, 10.0; 2.0, 20.0; 3.0, 30.0\n"
+        "##END=\n"
+    )
+
+    # 2. Test PEAKTABLE and XYPOINTS
+    content_peakt = (
+        "##TITLE=Test PEAKTABLE\n"
+        "##JCAMPDX=5.0\n"
+        "##DATATYPE=NMR SPECTRUM\n"
+        "##PEAKTABLE=(XY..XY)\n"
+        "1.0, 100.0\n"
+        "2.0, 200.0\n"
+        "##END=\n"
+    )
+
+    content_xypoints = (
+        "##TITLE=Test XYPOINTS\n"
+        "##JCAMPDX=5.0\n"
+        "##DATATYPE=NMR SPECTRUM\n"
+        "##XYPOINTS=(XY..XY)\n"
+        "1.5, 150.0\n"
+        "2.5, 250.0\n"
+        "##END=\n"
+    )
+
+    # 3. Test comma decimal separator
+    content_comma = (
+        "##TITLE=Test Comma\n"
+        "##JCAMPDX=5.0\n"
+        "##DATATYPE=NMR SPECTRUM\n"
+        "##DATA CLASS=XYDATA\n"
+        "##XYDATA=(X..XY)\n"
+        "1,0, 10,5; 2,0, 20,5\n"
+        "##END=\n"
+    )
+
+    # 4. Test scientific notation in XY pairs
+    content_sci = (
+        "##TITLE=Test Scientific\n"
+        "##JCAMPDX=5.0\n"
+        "##DATATYPE=NMR SPECTRUM\n"
+        "##XYPOINTS=(XY..XY)\n"
+        "1.5e3, 2.0E-1\n"
+        "##END=\n"
+    )
+
+    fd, path = tempfile.mkstemp()
+    try:
+        # Test XY coordinate parsing
+        with os.fdopen(fd, 'w') as f:
+            f.write(content_xy)
+        dic, data = ng.jcampdx.read(path)
+        assert data.shape == (1, 3, 2)
+        assert np.allclose(data[0], [[1.0, 10.0], [2.0, 20.0], [3.0, 30.0]])
+
+        # Test PEAKTABLE
+        fd2, path2 = tempfile.mkstemp()
+        with os.fdopen(fd2, 'w') as f:
+            f.write(content_peakt)
+        dic, data = ng.jcampdx.read(path2)
+        assert data.shape == (1, 2, 2)
+        assert np.allclose(data[0], [[1.0, 100.0], [2.0, 200.0]])
+        os.remove(path2)
+
+        # Test XYPOINTS
+        fd3, path3 = tempfile.mkstemp()
+        with os.fdopen(fd3, 'w') as f:
+            f.write(content_xypoints)
+        dic, data = ng.jcampdx.read(path3)
+        assert data.shape == (1, 2, 2)
+        assert np.allclose(data[0], [[1.5, 150.0], [2.5, 250.0]])
+        os.remove(path3)
+
+        # Test comma decimal parsing
+        fd4, path4 = tempfile.mkstemp()
+        with os.fdopen(fd4, 'w') as f:
+            f.write(content_comma)
+        dic, data = ng.jcampdx.read(path4)
+        assert data.shape == (1, 2, 2)
+        assert np.allclose(data[0], [[1.0, 10.5], [2.0, 20.5]])
+        os.remove(path4)
+
+        # Test scientific notation
+        fd5, path5 = tempfile.mkstemp()
+        with os.fdopen(fd5, 'w') as f:
+            f.write(content_sci)
+        dic, data = ng.jcampdx.read(path5)
+        assert data.shape == (1, 1, 2)
+        assert np.allclose(data[0], [[1500.0, 0.2]])
+        os.remove(path5)
+    finally:
+        os.remove(path)


### PR DESCRIPTION
### Summary

Extends the JCAMP-DX parser to handle several additional data formats commonly found in real-world `.jdx` files, particularly those produced by European instruments and IR/Raman spectrometers.

### Changes

**New data format: Coordinate list `(XY..XY)`**
- `_detect_format()` now detects coordinate pair format (returns mode `2`), including values in scientific notation (e.g. `1.5e3, 2.0E-1`).
- New `_parse_xy_xy()` function parses comma-separated X,Y coordinate pairs with full scientific notation support.

**New block types: `PEAKTABLE` and `XYPOINTS`**
- `getdataarray()` now falls back to parsing `##PEAKTABLE` and `##XYPOINTS` blocks if `XYDATA` and `NTUPLES` are not found.

**Locale-aware comma decimal separator**
- `_parse_data()` applies a heuristic: if the data portion contains commas but no dots, commas between digits are treated as decimal separators (e.g. `1,5` → `1.5`). This handles files written with European locale settings.

### Motivation

The JCAMP-DX standard (IUPAC) defines several data table formats beyond `XYDATA` and `NTUPLES`. Many IR, Raman, and mass spectrometry files use `PEAKTABLE` or `XYPOINTS`. Files from instruments with European locale settings use comma as the decimal separator. Without this support, `nmrglue` returns `None` for these files.

### Related Issues

Partially addresses the general need for broader JCAMP-DX format support.