### PR TITLE
Fix singular Bruker processing file discovery

### DIFF
--- a/nmrglue/fileio/bruker.py
+++ b/nmrglue/fileio/bruker.py
@@ -634,7 +634,8 @@ def read_procs_file(dir='.', procs_files=None):
         procs_files = []
 
         pdata_path = dir
-        for f in ["procs", "proc2s", "proc3s", "proc4s"]:
+        for f in ["procs", "proc", "proc2s", "proc2", "proc3s", "proc3",
+                  "proc4s", "proc4"]:
             pf = os.path.join(pdata_path, f)
             if os.path.isfile(pf):
                 procs_files.append(pf)
@@ -650,7 +651,8 @@ def read_procs_file(dir='.', procs_files=None):
                 else:
                     pdata_path = os.path.join(dir, 'pdata', pdata_folders[0])
 
-            for f in ["procs", "proc2s", "proc3s", "proc4s"]:
+            for f in ["procs", "proc", "proc2s", "proc2", "proc3s", "proc3",
+                      "proc4s", "proc4"]:
                 pf = os.path.join(pdata_path, f)
                 if os.path.isfile(pf):
                     procs_files.append(pf)

--- a/nmrglue/fileio/tests/test_bruker.py
+++ b/nmrglue/fileio/tests/test_bruker.py
@@ -37,6 +37,22 @@ def test_read_pdata():
     assert len(dic['procs'].keys()) == 131
 
 
+def test_read_procs_file_discovers_singular_proc():
+    """The current and status processing files are discovered separately."""
+
+    base = {"_coreheader": ["##TITLE= Parameter file"], "_comments": []}
+    with tempfile.TemporaryDirectory() as td:
+        ng.bruker.write_jcamp(dict(base, ABSF1=100), os.path.join(td, "procs"))
+        ng.bruker.write_jcamp(dict(base, ABSF1=200), os.path.join(td, "proc"))
+
+        explicit = ng.bruker.read_procs_file(td, ["procs", "proc"])
+        assert explicit["proc"]["ABSF1"] == 200
+
+        discovered = ng.bruker.read_procs_file(td)
+        assert discovered["procs"]["ABSF1"] == 100
+        assert discovered["proc"]["ABSF1"] == 200
+
+
 def test_reorder_submatrix():
     """reordering submatrix back and forth"""
 


### PR DESCRIPTION
## Summary

- discover the singular Bruker processing files (`proc`, `proc2`, `proc3`, and `proc4`) alongside their status-file counterparts
- preserve access to parameters such as `ABSF1` and `ABSF2` when TopSpin stores their current values only in the singular files
- add a focused regression test covering automatic discovery and explicit file lists

Fixes #253.

## Validation

- focused regression test: 1 passed on the exact upstream base and patch
- self-contained Bruker regression group: 4 passed on the exact upstream base and patch
- `git diff --check` and Python AST checks passed in the publication worktree
- the current publication environment could not recollect pytest because SciPy is not installed; no dependencies were installed for this submission

## AI assistance disclosure

This change was prepared and tested with OpenAI Codex. It is intentionally opened as a Draft for maintainer review. No automated issue/PR comments or Ready transition will be made.